### PR TITLE
fix: switch to service account secret

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:
@@ -16,9 +17,10 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: python
           package-name: mobster
-          changelog-types:  '[{"type":"feat","section":"Features","hidden":false},
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},
               {"type":"fix","section":"Bug Fixes","hidden":false},
               {"type":"docs","section":"Documentation","hidden":false},
               {"type":"test","section":"Tests","hidden":false},
@@ -30,7 +32,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/googleapis/release-please-action.git"
+          git remote add gh-token "https://${{ secrets.RELEASE_PLEASE_TOKEN }}@github.com/googleapis/release-please-action.git"
           git tag -d v${{ steps.release.outputs.major }} || true
           git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git push origin :v${{ steps.release.outputs.major }} || true


### PR DESCRIPTION
The release-please action uses the default Github token. When using this token any followup action is not triggered to avoid loops. This commit switches from default account to a new SA token that have permission to trigger any followup actions.