### PR TITLE
doc: Update a release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ the tool:
 
 ```bash
 pip install mobster
+mobster --help
 ```
 ### Using container image
 
-TODO: Add this section once the release is configured in Konflux.
+```bash
+podman pull quay.io/konflux-ci/mobster:latest
+podman run -it quay.io/konflux-ci/mobster:latest mobster --help
+```
 
 ## Development environment
 
@@ -50,6 +54,13 @@ We welcome contributions to the Mobster project! If you would like to contribute
 6. Wait for the review and address any comments or suggestions
 7. Once your changes are approved, they will be merged into the main branch
 8. Congratulations! You have successfully contributed to the Mobster project
+
+## Release process
+The release process is automated using GitHub Actions and Konflux. The process
+is described in detail in the [release.md](docs/release.md) file.
+
+## Documentation
+The documentation for the Mobster project is available in the [docs](/docs/) directory.
 
 ## License
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,25 +5,48 @@ Github Actions and Konflux. The Github Actions take care of the release process
 for the Python package and the Konflux takes care of the release process for the
 container image.
 
-## Release to PyPI
-A github action is used to release the Python package to PyPI. The action is
-triggered on every version tag (`vX.Y.Z`) being pushed to the repository.
+## Github Release
+The Mobster uses release-please CLI tool to automate the release process and
+generate the release notes. Unfortunately we can't use the release-please
+github action due to a security concern in the `konflux-ci` organization.
+
+Because of that the release process is done manually using the
+`release-please` CLI tool. The tool is used to generate the release notes and
+bump the version in the `pyproject.toml` file.
 
 ### Release steps:
 1. Pull the latest version from the repository. `git pull upstream main`
-2. Increment the version in `pyproject.toml` file. The version should be in the format
-   `X.Y.Z` where `X` is the major version, `Y` is the minor version and `Z` is
-   the patch version.
-3. Commit the changes to the repository. `git commit -m "Bump version to X.Y.Z"`
-4. Push the changes to the repository. `git push upstream main`
-5. Create a new tag for the release. `git tag vX.Y.Z`
-6. Push the tag to the repository. `git push upstream vX.Y.Z`
+2. Install the [release-please](https://github.com/googleapis/release-please/blob/main/docs/cli.md#running-release-please-cli) CLI tool if not already installed
+3. Run the release-please command to generate the release notes and bump the version:
+   ```bash
+   release-please release-pr \
+   --token=$GITHUB_TOKEN \ # personal access token with repo scope
+   --repo-url=https://github.com/konflux-ci/mobster
+   ```
+4. Review the generated pull request and merge it into the main branch.
+5. After the pull request is merged, tag the commit with the version number:
+   ```bash
+      git pull upstream main
+      git tag vX.Y.Z
+      git push upstream vX.Y.Z
+   ```
+6. Create a new release on GitHub with the tag `vX.Y.Z`. The release notes will
+   be automatically generated based on commit diff.
+
+## Release to PyPI
+A github action is used to release the Python package to PyPI. The action is
+triggered on every version tag (`vX.Y.Z`) being pushed to the repository.
+The tag event is generated from the previous [release steps](#release-steps).
 
 After the tag is pushed, the Github action will be triggered and it will
-automatically build the package and upload it to PyPI.
+automatically build the package and upload it to [PyPI](https://pypi.org/project/mobster/).
 
 ## Release to registry
-The Konflux is used to release the container image to the registry. The Konflux
+The Konflux is used to build and release the container image to the registry. The Konflux
 is configured to build image for every open PR and also for every merged PR.
 
-TODO: Add mode details about Konflux release process when a first release is done.
+The intermediate images are pushed to internal repository:
+- https://quay.io/repository/redhat-user-workloads/the-collective-tenant/mobster-f7a65
+
+The final externally available image is pushed to user facing repository:
+- https://quay.io/konflux-ci/mobster


### PR DESCRIPTION
The new release process is described in the release documentation. Release-please CLI tool is used to generate changelog, bump a version and prepare release pull request.

Konflux is also configured to build container images.