### PR TITLE
feat(ISV-6033): limit concurrency in SBOM augmentation

### DIFF
--- a/src/mobster/cli.py
+++ b/src/mobster/cli.py
@@ -266,6 +266,12 @@ def generate_augment_oci_image_parser(subparsers: Any) -> None:
         type=Path,
         help="path to public key used to verify the image provenance",
     )
+    augment_oci_image_parser.add_argument(
+        "--concurrency",
+        type=parse_concurrency,
+        default=8,
+        help="concurrency limit for SBOM updates (non-zero integer)",
+    )
 
     augment_oci_image_parser.set_defaults(func=augment.AugmentImageCommand)
 
@@ -309,3 +315,23 @@ def upload_tpa_parser(subparsers: Any) -> None:
     source_group.add_argument("--file", type=Path, help="File to upload")
 
     tpa_parser.set_defaults(func=upload.TPAUploadCommand)
+
+
+def parse_concurrency(val: str) -> int:
+    """Parse and validate concurrency limit from command line argument.
+
+    Args:
+        val: String value from command line argument.
+
+    Returns:
+        Validated integer concurrency limit.
+
+    Raises:
+        argparse.ArgumentTypeError: If value is not a positive integer.
+    """
+    num = int(val)
+    if num < 1:
+        raise argparse.ArgumentTypeError(
+            "Concurrency limit must be a non-zero integer."
+        )
+    return num

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,8 @@
-from mobster.cli import setup_arg_parser
+import argparse
+
+import pytest
+
+from mobster.cli import parse_concurrency, setup_arg_parser
 
 
 def test_setup_arg_parser() -> None:
@@ -6,3 +10,20 @@ def test_setup_arg_parser() -> None:
     parser = setup_arg_parser()
     assert parser is not None
     assert parser.description == "Mobster CLI"
+
+
+@pytest.mark.parametrize(
+    ["value", "expected"],
+    [
+        ("1", 1),
+        ("0", argparse.ArgumentTypeError),
+        ("-1", argparse.ArgumentTypeError),
+        ("not_a_number", ValueError),
+    ],
+)
+def test_parse_concurrency(value: str, expected: int | type) -> None:
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            parse_concurrency(value)
+    else:
+        assert parse_concurrency(value) == expected


### PR DESCRIPTION
To avoid blowing up memory for big augmentations, we set a concurrency limit. If in the future we find out this is too slow, we should come back and reevaluate. Since we know the size of the SBOMs before downloading them, we can quite accurately predict memory usage. That would allow us to set memory limits in the CLI instead of a concurrency limit. 