### PR TITLE
feat: Add version label to the Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,8 +38,12 @@ RUN .venv/bin/pip install awscli==1.40.33
 FROM registry.access.redhat.com/ubi9/python-312@sha256:2970a99fed0b2bc9597e6a69fb555d3ede9669007e3d113c725ef6909a53e727
 
 LABEL name="mobster" \
-      description="A tool for generating and managing Software Bill of Materials (SBOM)" \
-      maintainers="The Collective team"
+    description="A tool for generating and managing Software Bill of Materials (SBOM)" \
+    maintainers="The Collective team"
+
+# x-release-please-start-version
+LABEL version="0.3.0"
+# x-release-please-end
 
 # Set the working directory in the container
 WORKDIR /app

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,13 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "Containerfile"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
The label is controlled by the release-please and it is bumped up automatically. The label will be used to produce version tags in Quay in Konflux.