### PR TITLE
feat: Support multi-arch builds with all available arches

### DIFF
--- a/.tekton/mobster-f7a65-pull-request.yaml
+++ b/.tekton/mobster-f7a65-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Containerfile
   pipelineSpec:

--- a/.tekton/mobster-f7a65-push.yaml
+++ b/.tekton/mobster-f7a65-push.yaml
@@ -108,6 +108,9 @@ spec:
       type: string
     - default:
       - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array


### PR DESCRIPTION
A Mobster image will be produced with index image manifest with all provided arches.