### PR TITLE
fix: Add arch parameters to the right place

### DIFF
--- a/.tekton/mobster-f7a65-pull-request.yaml
+++ b/.tekton/mobster-f7a65-pull-request.yaml
@@ -114,6 +114,9 @@ spec:
       type: string
     - default:
       - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array

--- a/.tekton/mobster-f7a65-push.yaml
+++ b/.tekton/mobster-f7a65-push.yaml
@@ -26,6 +26,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Containerfile
   pipelineSpec:


### PR DESCRIPTION
The previous commit with a multiarch changes added a multiarch parameters to a default params instead of actual pipelinerun params. This caused that a PR builds produced multiarch images but builds triggered by the merge event still produces just a single arch.

This commit unifies both pipelines.