### PR TITLE
feat: Add extra logging to get precise metrics

### DIFF
--- a/src/mobster/cmd/augment/__init__.py
+++ b/src/mobster/cmd/augment/__init__.py
@@ -32,6 +32,13 @@ class AugmentImageCommand(Command):
         super().__init__(*args, **kwargs)
         self.sboms: list[SBOM] = []
 
+    @property
+    def name(self) -> str:
+        """
+        Name of the augment command used for logging purposes.
+        """
+        return "AugmentImageCommand"
+
     async def execute(self) -> Any:
         """
         Update OCI image SBOMs based on the supplied args.

--- a/src/mobster/cmd/base.py
+++ b/src/mobster/cmd/base.py
@@ -26,6 +26,13 @@ class Command(ABC):
 
         self._exit_code = value
 
+    @property
+    def name(self) -> str:
+        """
+        Name of the command, used for logging purposes.
+        """
+        return self.__class__.__name__
+
     @abstractmethod
     async def execute(self) -> Any:
         """

--- a/src/mobster/cmd/upload/upload.py
+++ b/src/mobster/cmd/upload/upload.py
@@ -129,6 +129,7 @@ class TPAUploadCommand(Command):
             start_time = time.time()
             try:
                 await client.upload_sbom(sbom_file)
+                LOGGER.info("Successfully uploaded %s to TPA", sbom_file)
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception(
                     "Error uploading %s and took %s", filename, time.time() - start_time

--- a/src/mobster/log.py
+++ b/src/mobster/log.py
@@ -4,8 +4,11 @@ Logging configuration and utility functions.
 
 import logging
 import logging.config
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def setup_logging(verbose: bool) -> None:
@@ -37,4 +40,26 @@ def setup_logging(verbose: bool) -> None:
     }
 
     logging.config.dictConfig(config=logconfig)
-    logger.info("Logging level set to %s", log_level)
+    LOGGER.info("Logging level set to %s", log_level)
+
+
+@contextmanager
+def log_elapsed(name: str) -> Generator[None, None, None]:
+    """
+    Log time elapsed in the with block.
+
+    Example:
+        >>> with log_elapsed("sleep"):
+                time.sleep(1)
+        "sleep completed in 1s"
+
+    Args:
+        name: The name of the action to log elapsed time of
+    """
+
+    start_time = time.time()
+    try:
+        yield
+    finally:
+        elapsed = time.time() - start_time
+        LOGGER.debug("%s completed in %.2fs", name, elapsed)

--- a/src/mobster/main.py
+++ b/src/mobster/main.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from mobster import cli
 from mobster.cmd.base import Command
-from mobster.log import setup_logging
+from mobster.log import log_elapsed, setup_logging
 
 LOGGER = logging.getLogger(__name__)
 
@@ -21,8 +21,9 @@ async def run(args: Any) -> None:
 
     """
     command: Command = args.func(args)
-    await command.execute()
-    await command.save()
+    with log_elapsed(command.name):
+        await command.execute()
+        await command.save()
     LOGGER.info("Exiting with code %s.", command.exit_code)
     sys.exit(command.exit_code)
 

--- a/tests/cmd/test_augment.py
+++ b/tests/cmd/test_augment.py
@@ -103,6 +103,17 @@ class TestAugmentCommand:
         return cmd
 
     @pytest.mark.asyncio
+    async def test_augment_command_name(
+        self,
+        augment_command_save: AugmentImageCommand,
+    ) -> None:
+        """
+        Test to avoid breaking monitoring in case that AugmentImageCommand is changed
+        Used by Splunk
+        """
+        assert augment_command_save.name == "AugmentImageCommand"
+
+    @pytest.mark.asyncio
     async def test_augment_command_save(
         self,
         augment_command_save: AugmentImageCommand,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,11 @@
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mobster.main import main, run
+
+LOGGER = logging.getLogger(__name__)
 
 
 @patch("mobster.main.run")
@@ -19,7 +22,10 @@ def test_main(mock_setup_args: MagicMock, mock_run: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_run(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_run(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     mock_args = MagicMock()
     mock_args.func = MagicMock()
     mock_args.func.return_value.execute = AsyncMock()
@@ -30,3 +36,6 @@ async def test_run(monkeypatch: pytest.MonkeyPatch) -> None:
 
     mock_args.func.return_value.execute.assert_called_once()
     mock_args.func.return_value.save.assert_called_once()
+
+    # check that log_elapsed log is present
+    assert "completed in" in caplog.text


### PR DESCRIPTION
This PR adds more precise logs to achieve two things:
- Get a confirmation of a successful sbom upload to TPA
- Get the time to execute a command

These two things will be used to build the Splunk dashboard gathering relevant metrics of the release-time sbom process.