### PR TITLE
feat: reduce image arch for pull request to x86_64

### DIFF
--- a/.tekton/mobster-f7a65-pull-request.yaml
+++ b/.tekton/mobster-f7a65-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Containerfile
   pipelineSpec:
@@ -114,9 +111,6 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
-      - linux/ppc64le
-      - linux/s390x
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array


### PR DESCRIPTION
I realized that running a build for each pull request makes the pipeline unnecessary long and we don't need the extra arches to be build for every PR.

This commit removes extra arches for pull request but keeps all arches for push pipelines. This make sure we still produce multi arch images for a Mobster releases.