### PR TITLE
fix: enable sbom batching to reduce OOMKills

### DIFF
--- a/src/mobster/cli.py
+++ b/src/mobster/cli.py
@@ -209,7 +209,7 @@ def generate_product_parser(subparsers: Any) -> None:
     product_parser.add_argument(
         "--concurrency",
         type=parse_concurrency,
-        default=8,
+        default=20,
         help="concurrency limit for snapshot parsing (non-zero integer)",
     )
 
@@ -337,7 +337,7 @@ def generate_augment_oci_image_parser(subparsers: Any) -> None:
     augment_oci_image_parser.add_argument(
         "--concurrency",
         type=parse_concurrency,
-        default=8,
+        default=20,
         help="concurrency limit for SBOM updates (non-zero integer)",
     )
     augment_oci_image_parser.add_argument(

--- a/src/mobster/release.py
+++ b/src/mobster/release.py
@@ -66,7 +66,7 @@ class Snapshot:
 
 
 async def make_snapshot(
-    snapshot_spec: Path, digest: str | None = None, concurrency_limit: int = 8
+    snapshot_spec: Path, digest: str | None = None, concurrency_limit: int = 20
 ) -> Snapshot:
     """
     Parse a snapshot spec from a JSON file and create an object representation

--- a/src/mobster/tekton/common.py
+++ b/src/mobster/tekton/common.py
@@ -36,6 +36,9 @@ class CommonArgs:
         snapshot_spec: path to snapshot spec file
         atlas_api_url: url of the TPA instance to use
         retry_s3_bucket: name of the S3 bucket to use for retries
+        release_id: release ID to use for SBOM annotations
+        print_digests: whether to print SBOM digests
+        concurrency: maximum number of SBOMs to process concurrently
     """
 
     data_dir: Path
@@ -44,6 +47,7 @@ class CommonArgs:
     retry_s3_bucket: str
     release_id: ReleaseId
     print_digests: bool
+    concurrency: int
 
 
 def add_common_args(parser: ArgumentParser) -> None:
@@ -59,6 +63,7 @@ def add_common_args(parser: ArgumentParser) -> None:
     parser.add_argument("--retry-s3-bucket", type=str)
     parser.add_argument("--release-id", type=ReleaseId, required=True)
     parser.add_argument("--print-digests", action="store_true")
+    parser.add_argument("--concurrency", type=int, default=20)
 
 
 async def upload_sboms(

--- a/src/mobster/tekton/product.py
+++ b/src/mobster/tekton/product.py
@@ -58,6 +58,7 @@ def parse_args() -> ProcessProductArgs:
         retry_s3_bucket=args.retry_s3_bucket,
         release_id=args.release_id,
         print_digests=args.print_digests,
+        concurrency=args.concurrency,
     )  # pylint:disable=duplicate-code
 
 

--- a/tasks/augment-component-sboms-ta/0.1/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.1/augment-component-sboms-ta.yaml
@@ -86,6 +86,11 @@ spec:
       default: ""
       type: string
 
+    - name: concurrency
+      description: Maximum number of SBOMs to process concurrently.
+      default: "20"
+      type: string
+
   workspaces:
     - name: data
       description: Used as a working directory.
@@ -194,7 +199,8 @@ spec:
           --snapshot-spec "$(params.snapshotSpec)" \
           --atlas-api-url "$(params.atlasApiUrl)" \
           --retry-s3-bucket "$(params.retryS3Bucket)" \
-          --release-id "$release_id"
+          --release-id "$release_id" \
+          --concurrency "$(params.concurrency)"
 
     - name: create-trusted-artifact
       ref:


### PR DESCRIPTION
While we added concurrency previously, that still caused all of the augmented SBOMs to be stored in memory resulting in OOMKills when large snapshots were processed. This change limits the number of SBOMs that are stored in memory by processing them in batches.

Assisted-by: Claude
Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED