### PR TITLE
feat(KONFLUX-9780): use normalized image names for SBOM ids

### DIFF
--- a/src/mobster/image.py
+++ b/src/mobster/image.py
@@ -219,6 +219,14 @@ class Image:  # pylint: disable=too-many-instance-attributes
         """
         return self.repository.rsplit("/", 1)[-1]
 
+    @property
+    def normalized_name(self) -> str:
+        """
+        Name of the image normalized to contain only alphanumeric characters
+        and hyphens.
+        """
+        return re.sub(r"[^0-9a-zA-Z\.\-\+]", "-", self.name)
+
     def purl(self) -> PackageURL:
         """
         A package URL representation of the image in string format.
@@ -257,7 +265,7 @@ class Image:  # pylint: disable=too-many-instance-attributes
             str: A proposed SPDX ID for the image.
         """
         purl_hex_digest = hashlib.sha256(self.purl_str().encode()).hexdigest()
-        return f"SPDXRef-image-{self.name}-{purl_hex_digest}"
+        return f"SPDXRef-image-{self.normalized_name}-{purl_hex_digest}"
 
     def propose_cyclonedx_bom_ref(self) -> str:
         """
@@ -269,7 +277,7 @@ class Image:  # pylint: disable=too-many-instance-attributes
             str: A proposed CycloneDX BOM reference for the image.
         """
         purl_hex_digest = hashlib.sha256(self.purl_str().encode()).hexdigest()
-        return f"BomRef.{self.name}-{purl_hex_digest}"
+        return f"BomRef.{self.normalized_name}-{purl_hex_digest}"
 
     def propose_sbom_name(self) -> str:
         """

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -53,6 +53,22 @@ def test_image() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ["repository", "expected_id"],
+    [
+        ("repo/name", "SPDXRef-image-name"),
+        ("repo/name2", "SPDXRef-image-name2"),
+        ("repo/name_stupid", "SPDXRef-image-name-stupid"),
+        ("repo/name@weird", "SPDXRef-image-name-weird"),
+    ],
+)
+def test_image_spdx_id(repository: str, expected_id: str) -> None:
+    image = Image(repository=repository, digest="sha256:aaaa")
+    # drop the last 65 chars - purl digest and separator
+    actual = image.propose_spdx_id()[:-65]
+    assert actual == expected_id
+
+
 def test_image_from_oci_artifact_reference() -> None:
     """
     Test the from_oci_artifact_reference method of the Image class.


### PR DESCRIPTION
https://issues.redhat.com/browse/KONFLUX-9780