### PR TITLE
feat: Bump up Mobster image in Tekton task

### DIFF
--- a/tasks/augment-component-sboms-ta/0.1/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.1/augment-component-sboms-ta.yaml
@@ -161,7 +161,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: process-component-sboms
-      image: quay.io/konflux-ci/mobster@sha256:3785f754968dc1a7332698eaeaf1e0681d04f107fb9fd22868030ffb6e667fd1
+      image: quay.io/konflux-ci/mobster@sha256:20b297f5cbd1db36d7ade2c15100e7eb8cf57e0554ef69bd92ed7282b29e89f5
       env:
         - name: MOBSTER_TPA_SSO_ACCOUNT
           valueFrom:

--- a/tasks/augment-component-sboms-ta/0.2/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.2/augment-component-sboms-ta.yaml
@@ -141,7 +141,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: process-component-sboms
-      image: quay.io/konflux-ci/mobster@sha256:3785f754968dc1a7332698eaeaf1e0681d04f107fb9fd22868030ffb6e667fd1
+      image: quay.io/konflux-ci/mobster@sha256:20b297f5cbd1db36d7ade2c15100e7eb8cf57e0554ef69bd92ed7282b29e89f5
       env:
         - name: MOBSTER_TPA_SSO_ACCOUNT
           valueFrom:

--- a/tasks/create-product-sbom-ta/0.1/create-product-sbom-ta.yaml
+++ b/tasks/create-product-sbom-ta/0.1/create-product-sbom-ta.yaml
@@ -157,7 +157,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: process-product-sbom
-      image: quay.io/konflux-ci/mobster@sha256:3785f754968dc1a7332698eaeaf1e0681d04f107fb9fd22868030ffb6e667fd1
+      image: quay.io/konflux-ci/mobster@sha256:20b297f5cbd1db36d7ade2c15100e7eb8cf57e0554ef69bd92ed7282b29e89f5
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/create-product-sbom-ta/0.2/create-product-sbom-ta.yaml
+++ b/tasks/create-product-sbom-ta/0.2/create-product-sbom-ta.yaml
@@ -138,7 +138,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: process-product-sbom
-      image: quay.io/konflux-ci/mobster@sha256:3785f754968dc1a7332698eaeaf1e0681d04f107fb9fd22868030ffb6e667fd1
+      image: quay.io/konflux-ci/mobster@sha256:20b297f5cbd1db36d7ade2c15100e7eb8cf57e0554ef69bd92ed7282b29e89f5
       computeResources:
         limits:
           memory: 1Gi


### PR DESCRIPTION
The latest image contains modification of SBOM purls to also include architecture for oci image and index image.