### PR TITLE
feat(ISV-5820): Attest the release-time SBOM to the registry -- update Tekton tasks.

### DIFF
--- a/tasks/augment-component-sboms-ta/0.1/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.1/augment-component-sboms-ta.yaml
@@ -106,6 +106,14 @@ spec:
       type: string
       description: Path to directory in the dataDir to store JSON task results to.
 
+    - name: cosignSecretName
+      type: string
+      description: K8s secret name with a cosign signing key used for SBOM attestation.
+
+    - name: attestationPubKey
+      type: string
+      description: K8s reference to a secret containing a key for verifying provenance attestations
+
   workspaces:
     - name: data
       description: Used as a working directory.
@@ -165,7 +173,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: process-component-sboms
-      image: quay.io/konflux-ci/mobster@sha256:d46f25aed27c9ffc737709866ddb2594d3c2c80319529d86520a0bf745596af1
+      image: quay.io/konflux-ci/mobster@sha256:f892227eed6c448b0f444eab6e1c8c8456ebd9b5bb8d629e6f7cc7492f25e626
       env:
         - name: MOBSTER_TPA_SSO_ACCOUNT
           valueFrom:
@@ -195,6 +203,26 @@ spec:
               optional: true
         - name: AWS_DEFAULT_REGION
           value: "us-east-1"
+        - name: SIGN_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: SIGN_KEY
+        - name: COSIGN_AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: AWS_DEFAULT_REGION
+        - name: COSIGN_AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: AWS_ACCESS_KEY_ID
+        - name: COSIGN_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: AWS_SECRET_ACCESS_KEY
       computeResources:
         limits:
           memory: 1Gi
@@ -217,7 +245,10 @@ spec:
           --retry-s3-bucket "$(params.retryS3Bucket)" \
           --release-id "$release_id" \
           --augment-concurrency "$(params.augmentConcurrency)" \
-          --upload-concurrency "$(params.uploadConcurrency)"
+          --upload-concurrency "$(params.uploadConcurrency)" \
+          --result-dir "$(params.resultsDirPath)" \
+          --sign-key "$SIGN_KEY" \
+          --verify-key "$(params.attestationPubKey)"
 
     - name: create-trusted-artifact
       ref:

--- a/tasks/augment-component-sboms-ta/0.2/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.2/augment-component-sboms-ta.yaml
@@ -106,6 +106,14 @@ spec:
       type: string
       description: Path to directory in the dataDir to store JSON task results to.
 
+    - name: cosignSecretName
+      type: string
+      description: K8s secret name with a cosign signing key used for SBOM attestation.
+
+    - name: attestationPubKey
+      type: string
+      description: K8s reference to a secret containing a key for verifying provenance attestations
+
   results:
     - description: Produced trusted data artifact
       name: sourceDataArtifact
@@ -145,7 +153,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: process-component-sboms
-      image: quay.io/konflux-ci/mobster@sha256:d46f25aed27c9ffc737709866ddb2594d3c2c80319529d86520a0bf745596af1
+      image: quay.io/konflux-ci/mobster@sha256:f892227eed6c448b0f444eab6e1c8c8456ebd9b5bb8d629e6f7cc7492f25e626
       env:
         - name: MOBSTER_TPA_SSO_ACCOUNT
           valueFrom:
@@ -175,6 +183,26 @@ spec:
               optional: true
         - name: AWS_DEFAULT_REGION
           value: "us-east-1"
+        - name: SIGN_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: SIGN_KEY
+        - name: COSIGN_AWS_DEFAULT_REGION
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: AWS_DEFAULT_REGION
+        - name: COSIGN_AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: AWS_ACCESS_KEY_ID
+        - name: COSIGN_AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.cosignSecretName)
+              key: AWS_SECRET_ACCESS_KEY
       computeResources:
         limits:
           memory: 1Gi
@@ -197,7 +225,9 @@ spec:
           --release-id "$release_id" \
           --augment-concurrency "$(params.augmentConcurrency)" \
           --upload-concurrency "$(params.uploadConcurrency)" \
-          --result-dir "$(params.resultsDirPath)"
+          --result-dir "$(params.resultsDirPath)" \
+          --sign-key "$SIGN_KEY" \
+          --verify-key "$(params.attestationPubKey)"
 
     - name: create-trusted-artifact
       ref:


### PR DESCRIPTION
I have run the e2e pipeline on this commit, the output is [visible here](https://github.com/konflux-ci/release-service-catalog/pull/1453/checks?check_run_id=51581853930). To check the output, you can inspect the published image by `cosign tree registry.stage.redhat.io/rhtap/rh-advisories-component@sha256:c6ade1892f238e9e59fd97e6c80cd211544b1ab05298bda1ad4977c65fbfdb0a` (I got the digest by running the command on tag `latest` immediately after my pipeline finished).