### PR TITLE
feat(ISV-5914): utilize connection pooling in TPA client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ packages = [{ include = "mobster", from = "src" }]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')"
 ]

--- a/src/mobster/cmd/delete/delete_tpa.py
+++ b/src/mobster/cmd/delete/delete_tpa.py
@@ -22,16 +22,15 @@ class TPADeleteCommand(Command):
         """
         Execute the command to delete SBOMs from the TPA.
         """
-        tpa_client = get_tpa_default_client(self.cli_args.tpa_base_url)
+        async with get_tpa_default_client(self.cli_args.tpa_base_url) as client:
+            sboms = client.list_sboms(query=self.cli_args.query, sort="ingested")
 
-        sboms = tpa_client.list_sboms(query=self.cli_args.query, sort="ingested")
-
-        async for sbom in sboms:
-            if self.cli_args.dry_run:
-                LOGGER.info("Would delete SBOM: %s (%s)", sbom.id, sbom.name)
-                continue
-            await tpa_client.delete_sbom(sbom.id)
-            LOGGER.info("Deleted SBOM:  %s (%s)", sbom.id, sbom.name)
+            async for sbom in sboms:
+                if self.cli_args.dry_run:
+                    LOGGER.info("Would delete SBOM: %s (%s)", sbom.id, sbom.name)
+                    continue
+                await client.delete_sbom(sbom.id)
+                LOGGER.info("Deleted SBOM:  %s (%s)", sbom.id, sbom.name)
         self.exit_code = 0
 
     async def save(self) -> None:

--- a/tests/cmd/upload/test_oidc.py
+++ b/tests/cmd/upload/test_oidc.py
@@ -1,29 +1,34 @@
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import pytest_asyncio
+from pytest_httpx import HTTPXMock, IteratorStream
 
 from mobster.cmd.upload import oidc
-from mobster.cmd.upload.oidc import RetryExhaustedException
+from mobster.cmd.upload.oidc import OIDCClientCredentialsClient, RetryExhaustedException
 
 AUTHORIZATION_HEADER = {"Authorization": "Bearer asdfghjkl"}
 
+BASE_URL = "https://api.example.com/v1/"
 
-def _get_valid_client() -> oidc.OIDCClientCredentialsClient:
+
+@pytest_asyncio.fixture
+async def oidc_client() -> AsyncGenerator[oidc.OIDCClientCredentialsClient, None]:
     token_url = "https://auth.example.com/oidc/token"
     proxy = "http://proxy.example.com:3128"
     auth = oidc.OIDCClientCredentials(
         token_url=token_url, client_id="abc", client_secret="xyz"
     )
-    oidc_client = oidc.OIDCClientCredentialsClient(
-        "https://api.example.com/v1/", auth, proxy=proxy
-    )
-    return oidc_client
+    async with oidc.OIDCClientCredentialsClient(BASE_URL, auth, proxy=proxy) as client:
+        yield client
 
 
 @pytest.mark.asyncio
-async def test__fetch_token_success(httpx_mock: Any) -> None:
+async def test__fetch_token_success(
+    httpx_mock: HTTPXMock, oidc_client: OIDCClientCredentialsClient
+) -> None:
     form_encoded_content_type = {"Content-Type": "application/x-www-form-urlencoded"}
     token_url = "https://auth.example.com/oidc/token"
     token_response = {"access_token": "asdfghjkl", "expires_in": 600}
@@ -35,27 +40,24 @@ async def test__fetch_token_success(httpx_mock: Any) -> None:
         json=token_response,
     )
 
-    client = _get_valid_client()
-    await client._fetch_token()
-    assert client._token == "asdfghjkl"
-    assert client._token_expiration > 0
+    await oidc_client._fetch_token()
+    assert oidc_client._token == "asdfghjkl"
+    assert oidc_client._token_expiration > 0
 
 
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.oidc.LOGGER")
 @patch("httpx.AsyncClient.post")
 async def test__fetch_token_unable(
-    mock_post: AsyncMock, mock_logger: MagicMock
+    mock_post: AsyncMock,
+    mock_logger: MagicMock,
+    oidc_client: OIDCClientCredentialsClient,
 ) -> None:
-    auth = oidc.OIDCClientCredentials(
-        token_url="foo", client_id="abc", client_secret="xyz"
-    )
-    client = oidc.OIDCClientCredentialsClient("bar", auth)
     request = httpx.Request("POST", "foo")
     mock_post.return_value = httpx.Response(500, request=request)
 
     with pytest.raises(httpx.HTTPStatusError):
-        await client._fetch_token()
+        await oidc_client._fetch_token()
 
     mock_logger.error.assert_called_once_with(
         "Unable to fetch auth token. [%s] %s", 500, ""
@@ -63,15 +65,15 @@ async def test__fetch_token_unable(
 
 
 @pytest.mark.asyncio
-async def test__fetch_token_failed(httpx_mock: Any) -> None:
+async def test__fetch_token_failed_unauthorized(
+    httpx_mock: HTTPXMock, oidc_client: OIDCClientCredentialsClient
+) -> None:
     form_encoded_content_type = {"Content-Type": "application/x-www-form-urlencoded"}
     token_error_url = "https://auth.example.com/oidc/fail/token"
     token_error_response = {
         "error": "unauthorized_client",
         "error_description": "Invalid client secret",
     }
-    token_invalid_url = "https://auth.example.com/oidc/invalid/token"
-    token_invalid_response = {"something": "else"}
 
     httpx_mock.add_response(
         url=token_error_url,
@@ -79,46 +81,57 @@ async def test__fetch_token_failed(httpx_mock: Any) -> None:
         headers=form_encoded_content_type,
         json=token_error_response,
     )
+    # error response
+    auth = oidc.OIDCClientCredentials(
+        token_url=token_error_url, client_id="abc", client_secret="xyz"
+    )
+    oidc_client._auth = auth
+
+    with pytest.raises(oidc.OIDCAuthenticationError) as exc:
+        await oidc_client._fetch_token()
+    assert "unauthorized_client" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test__fetch_token_failed_invalid(
+    httpx_mock: HTTPXMock, oidc_client: OIDCClientCredentialsClient
+) -> None:
+    form_encoded_content_type = {"Content-Type": "application/x-www-form-urlencoded"}
+    token_invalid_url = "https://auth.example.com/oidc/invalid/token"
+    token_invalid_response = {"something": "else"}
+
     httpx_mock.add_response(
         url=token_invalid_url,
         method="post",
         headers=form_encoded_content_type,
         json=token_invalid_response,
     )
-    # error response
-    auth = oidc.OIDCClientCredentials(
-        token_url=token_error_url, client_id="abc", client_secret="xyz"
-    )
-    error_client = oidc.OIDCClientCredentialsClient("https://api.example.com/v1/", auth)
-
-    with pytest.raises(oidc.OIDCAuthenticationError) as exc:
-        await error_client._fetch_token()
-    assert "unauthorized_client" in str(exc.value)
-
     # invalid response
     auth = oidc.OIDCClientCredentials(
         token_url=token_invalid_url, client_id="abc", client_secret="xyz"
     )
-    error_client = oidc.OIDCClientCredentialsClient("https://api.example.com/v1/", auth)
+    oidc_client._auth = auth
     with pytest.raises(oidc.OIDCAuthenticationError) as exc:
-        await error_client._fetch_token()
+        await oidc_client._fetch_token()
     assert "Authentication server did not provide a token" in str(exc.value)
 
 
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
-async def test__request(mock_fetch_token: AsyncMock, httpx_mock: Any) -> None:
-    client = _get_valid_client()
-
+async def test__request(
+    mock_fetch_token: AsyncMock,
+    httpx_mock: HTTPXMock,
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
     httpx_mock.add_response(
-        url="https://api.example.com/v1/hello",
+        url=f"{BASE_URL}hello",
         method="put",
         headers=AUTHORIZATION_HEADER,
         status_code=200,
         text="Hello, world!",
     )
 
-    resp = await client._request(
+    resp = await oidc_client._request(
         "put",
         "hello",
         headers={"header": "test"},
@@ -133,17 +146,17 @@ async def test__request(mock_fetch_token: AsyncMock, httpx_mock: Any) -> None:
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
 async def test__request_not_on_force_list(
-    mock_fetch_token: AsyncMock, httpx_mock: Any
+    mock_fetch_token: AsyncMock,
+    httpx_mock: HTTPXMock,
+    oidc_client: OIDCClientCredentialsClient,
 ) -> None:
-    client = _get_valid_client()
-
     httpx_mock.add_response(
-        url="https://api.example.com/v1/hello",
+        url=f"{BASE_URL}hello",
         method="put",
         headers=AUTHORIZATION_HEADER,
         status_code=403,
     )
-    resp = await client._request(
+    resp = await oidc_client._request(
         "put",
         "hello",
         headers={"header": "test"},
@@ -159,20 +172,20 @@ async def test__request_not_on_force_list(
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
 async def test__request_fail_with_retry_on_status(
-    mock_fetch_token: AsyncMock, httpx_mock: Any
+    mock_fetch_token: AsyncMock,
+    httpx_mock: HTTPXMock,
+    oidc_client: OIDCClientCredentialsClient,
 ) -> None:
-    client = _get_valid_client()
-
     retries = 2
     for _ in range(retries):
         httpx_mock.add_response(
-            url="https://api.example.com/v1/hello",
+            url=f"{BASE_URL}hello",
             method="put",
             headers=AUTHORIZATION_HEADER,
             status_code=500,
         )
     with pytest.raises(RetryExhaustedException):
-        await client._request(
+        await oidc_client._request(
             "put",
             "hello",
             headers={"header": "test"},
@@ -191,12 +204,12 @@ async def test__request_fail_with_retry_on_status(
 async def test__request_fail_on_request(
     mock_fetch_token: AsyncMock,
     mock_httpx_request: AsyncMock,
+    oidc_client: OIDCClientCredentialsClient,
 ) -> None:
-    client = _get_valid_client()
     mock_httpx_request.side_effect = httpx.RequestError("Request failed")
 
     with pytest.raises(RetryExhaustedException):
-        await client._request(
+        await oidc_client._request(
             "post",
             "hello",
             headers={"header": "test"},
@@ -215,12 +228,12 @@ async def test__request_fail_on_request(
 async def test__request_fail_on_error(
     mock_fetch_token: AsyncMock,
     mock_httpx_request: AsyncMock,
+    oidc_client: OIDCClientCredentialsClient,
 ) -> None:
-    client = _get_valid_client()
     mock_httpx_request.side_effect = ZeroDivisionError("Error")
 
     with pytest.raises(ZeroDivisionError):
-        await client._request(
+        await oidc_client._request(
             "post",
             "hello",
             headers={"header": "test"},
@@ -233,16 +246,14 @@ async def test__request_fail_on_error(
 
 
 @pytest.mark.asyncio
-async def test_put() -> None:
-    client = _get_valid_client()
-
+async def test_put(oidc_client: OIDCClientCredentialsClient) -> None:
     with patch.object(
-        client,
+        oidc_client,
         "_request",
         new_callable=AsyncMock,
         return_value=MagicMock(),
     ) as mock_request:
-        await client.put("foo", '{"file": ""}', headers={"header": "test"})
+        await oidc_client.put("foo", '{"file": ""}', headers={"header": "test"})
 
         mock_request.assert_awaited_once_with(
             "put",
@@ -255,16 +266,14 @@ async def test_put() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post() -> None:
-    client = _get_valid_client()
-
+async def test_post(oidc_client: OIDCClientCredentialsClient) -> None:
     with patch.object(
-        client,
+        oidc_client,
         "_request",
         new_callable=AsyncMock,
         return_value=MagicMock(),
     ) as mock_request:
-        await client.post("foo", '{"file": ""}', headers={"header": "test"})
+        await oidc_client.post("foo", '{"file": ""}', headers={"header": "test"})
 
         mock_request.assert_awaited_once_with(
             "post",
@@ -277,36 +286,37 @@ async def test_post() -> None:
 
 
 @pytest.mark.asyncio
-async def test__fetch_token_disabled_auth() -> None:
+async def test__fetch_token_disabled_auth(
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
     """
     Test that _fetch_token() returns early when auth is None.
     """
-    client = oidc.OIDCClientCredentialsClient("https://api.example.com", auth=None)
-    await client._fetch_token()  # Should not raise any exception
+    oidc_client._auth = None
+    await oidc_client._fetch_token()  # Should not raise any exception
 
 
 @pytest.mark.asyncio
-async def test__ensure_valid_token_disabled_auth() -> None:
+async def test__ensure_valid_token_disabled_auth(
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
     """
     Test that _ensure_valid_token() returns early when auth is None.
     """
-    client = oidc.OIDCClientCredentialsClient("https://api.example.com", auth=None)
-
+    oidc_client._auth = None
     # Should not raise any exception
-    await client._ensure_valid_token(None)  # type: ignore
+    await oidc_client._ensure_valid_token()
 
 
 @pytest.mark.asyncio
-async def test_get() -> None:
-    client = _get_valid_client()
-
+async def test_get(oidc_client: OIDCClientCredentialsClient) -> None:
     with patch.object(
-        client,
+        oidc_client,
         "_request",
         new_callable=AsyncMock,
         return_value=MagicMock(),
     ) as mock_request:
-        await client.get("foo", headers={"header": "test"})
+        await oidc_client.get("foo", headers={"header": "test"})
 
         mock_request.assert_awaited_once_with(
             "get",
@@ -318,16 +328,14 @@ async def test_get() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete() -> None:
-    client = _get_valid_client()
-
+async def test_delete(oidc_client: OIDCClientCredentialsClient) -> None:
     with patch.object(
-        client,
+        oidc_client,
         "_request",
         new_callable=AsyncMock,
         return_value=MagicMock(),
     ) as mock_request:
-        await client.delete("foo", headers={"header": "test"})
+        await oidc_client.delete("foo", headers={"header": "test"})
 
         mock_request.assert_awaited_once_with(
             "delete",
@@ -340,37 +348,15 @@ async def test_delete() -> None:
 
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._ensure_valid_token")
-@patch("httpx.AsyncClient")
 async def test_stream(
-    mock_async_client_class: MagicMock, mock_ensure_valid_token: AsyncMock
+    mock_ensure_valid_token: AsyncMock,
+    oidc_client: OIDCClientCredentialsClient,
+    httpx_mock: HTTPXMock,
 ) -> None:
-    client = _get_valid_client()
+    httpx_mock.add_response(stream=IteratorStream([b"chunk1", b"chunk2"]))
 
-    # Mock the httpx.AsyncClient instance
-    mock_client_instance = MagicMock()
-    mock_client_instance.headers = {}
-
-    # Mock the response object
-    mock_response = AsyncMock()
-    mock_response.raise_for_status = Mock()
-
-    # Mock aiter_bytes to return an async iterator
-    async def mock_aiter_bytes() -> Any:
-        for chunk in [b"chunk1", b"chunk2"]:
-            yield chunk
-
-    mock_response.aiter_bytes = mock_aiter_bytes
-
-    # Mock the stream context manager
-    mock_stream_context = AsyncMock()
-    mock_stream_context.__aenter__.return_value = mock_response
-    mock_stream_context.__aexit__.return_value = None
-    mock_client_instance.stream.return_value = mock_stream_context
-    mock_async_client_class.return_value = mock_client_instance
-
-    # Call the stream method and collect results
     result_chunks = []
-    async for chunk in client.stream(
+    async for chunk in oidc_client.stream(
         "GET",
         "api/v2/sbom/123/download",
         headers={"custom-header": "value"},
@@ -378,21 +364,18 @@ async def test_stream(
     ):
         result_chunks.append(chunk)
 
-    # Verify httpx.AsyncClient was created with correct parameters
-    mock_async_client_class.assert_called_once_with(proxy=client._proxies, timeout=60)
-
-    # Verify token was ensured
-    mock_ensure_valid_token.assert_awaited_once_with(mock_client_instance)
-
-    # Verify the stream method was called with correct parameters
-    mock_client_instance.stream.assert_called_once_with(
-        "GET",
-        "https://api.example.com/v1/api/v2/sbom/123/download",
-        params={"param1": "value1"},
-    )
-
-    # Verify response status was checked
-    mock_response.raise_for_status.assert_called_once()
-
-    # Verify we got the expected chunks
+    mock_ensure_valid_token.assert_awaited_once()
     assert result_chunks == [b"chunk1", b"chunk2"]
+
+
+def test__assert_client_raises_when_client_is_none() -> None:
+    """
+    Test that _assert_client() raises RuntimeError when client is None.
+    """
+    client = OIDCClientCredentialsClient(BASE_URL, None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="The client was not initialized using an async context manager",
+    ):
+        client._assert_client()

--- a/tests/cmd/upload/test_tpa.py
+++ b/tests/cmd/upload/test_tpa.py
@@ -1,30 +1,35 @@
 import json
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+import pytest_asyncio
 
 from mobster.cmd.upload.oidc import OIDCClientCredentials, RetryExhaustedException
 from mobster.cmd.upload.tpa import TPAClient, TPAError, TPATransientError
 
+BASE_URL = "https://api.example.com/v1/"
 
-def _get_valid_client() -> TPAClient:
+
+@pytest_asyncio.fixture
+async def tpa_client() -> AsyncGenerator[TPAClient, None]:
     token_url = "https://auth.example.com/oidc/token"
     proxy = "http://proxy.example.com:3128"
     auth = OIDCClientCredentials(
         token_url=token_url, client_id="abc", client_secret="xyz"
     )
-    tpa_client = TPAClient("https://api.example.com/v1/", auth, proxy=proxy)
-    return tpa_client
+    async with TPAClient(BASE_URL, auth, proxy=proxy) as client:
+        yield client
 
 
 @pytest.mark.asyncio
 @patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_success(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock
+    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
 ) -> None:
     sbom_filepath = Path("/path/to/sbom.json")
     file_content = b'{"sbom": "content"}'
@@ -40,8 +45,7 @@ async def test_upload_sbom_success(
     )
     mock_post.return_value = mock_response
 
-    client = _get_valid_client()
-    response = await client.upload_sbom(sbom_filepath)
+    response = await tpa_client.upload_sbom(sbom_filepath)
 
     mock_aiofiles_open.assert_called_once_with(sbom_filepath, "rb")
     mock_post.assert_called_once_with(
@@ -58,7 +62,7 @@ async def test_upload_sbom_success(
 @patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_error(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock
+    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
 ) -> None:
     sbom_filepath = Path("/path/to/sbom.json")
     file_content = b'{"sbom": "content"}'
@@ -68,14 +72,13 @@ async def test_upload_sbom_error(
     mock_aiofiles_open.return_value.__aenter__.return_value = mock_file
 
     request = httpx.Request("POST", "https://api.example.com/v1/api/v2/sbom")
-    error_response = httpx.Response(500, request=request)
+    error_response = httpx.Response(500, request=request, content=b"Server Error")
     mock_post.side_effect = httpx.HTTPStatusError(
         "Server Error", request=request, response=error_response
     )
 
-    client = _get_valid_client()
     with pytest.raises(TPAError):
-        await client.upload_sbom(sbom_filepath)
+        await tpa_client.upload_sbom(sbom_filepath)
 
     mock_aiofiles_open.assert_called_once_with(sbom_filepath, "rb")
     mock_post.assert_called_once()
@@ -85,7 +88,7 @@ async def test_upload_sbom_error(
 @patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_retry_exhausted_error(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock
+    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
 ) -> None:
     sbom_filepath = Path("/path/to/sbom.json")
     file_content = b'{"sbom": "content"}'
@@ -96,16 +99,15 @@ async def test_upload_sbom_retry_exhausted_error(
 
     mock_post.side_effect = RetryExhaustedException("Retries exhausted")
 
-    client = _get_valid_client()
     with pytest.raises(TPATransientError):
-        await client.upload_sbom(sbom_filepath)
+        await tpa_client.upload_sbom(sbom_filepath)
 
 
 @pytest.mark.asyncio
 @patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_http_error(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock
+    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
 ) -> None:
     sbom_filepath = Path("/path/to/sbom.json")
     file_content = b'{"sbom": "content"}'
@@ -116,14 +118,13 @@ async def test_upload_sbom_http_error(
 
     mock_post.side_effect = httpx.HTTPError("Connection failed")
 
-    client = _get_valid_client()
     with pytest.raises(TPAError):
-        await client.upload_sbom(sbom_filepath)
+        await tpa_client.upload_sbom(sbom_filepath)
 
 
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.tpa.TPAClient.get")
-async def test_list_sboms(mock_get: AsyncMock) -> None:
+async def test_list_sboms(mock_get: AsyncMock, tpa_client: TPAClient) -> None:
     """Test listing SBOMs from TPA API."""
     # Create mock response data that matches the expected model structure
     mock_sbom_data_1 = {
@@ -169,8 +170,7 @@ async def test_list_sboms(mock_get: AsyncMock) -> None:
 
     mock_get.side_effect = [page_one, page_two]
 
-    client = _get_valid_client()
-    response = client.list_sboms("query", "sort")
+    response = tpa_client.list_sboms("query", "sort")
 
     items = [item async for item in response]
 
@@ -183,9 +183,8 @@ async def test_list_sboms(mock_get: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 @patch("mobster.cmd.upload.tpa.TPAClient.delete")
-async def test_delete_sbom(mock_delete: AsyncMock) -> None:
-    client = _get_valid_client()
-    response = await client.delete_sbom("123")
+async def test_delete_sbom(mock_delete: AsyncMock, tpa_client: TPAClient) -> None:
+    response = await tpa_client.delete_sbom("123")
 
     mock_delete.assert_awaited_once_with("api/v2/sbom/123")
     assert response == mock_delete.return_value
@@ -195,7 +194,7 @@ async def test_delete_sbom(mock_delete: AsyncMock) -> None:
 @patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.stream")
 async def test_download_sbom(
-    mock_stream: AsyncMock, mock_aiofiles_open: AsyncMock
+    mock_stream: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
 ) -> None:
     """Test downloading SBOM from TPA API."""
     sbom_id = "123"
@@ -210,8 +209,7 @@ async def test_download_sbom(
     mock_file = AsyncMock()
     mock_aiofiles_open.return_value.__aenter__.return_value = mock_file
 
-    client = _get_valid_client()
-    await client.download_sbom(sbom_id, local_path)
+    await tpa_client.download_sbom(sbom_id, local_path)
 
     mock_stream.assert_called_once_with("GET", f"api/v2/sbom/{sbom_id}/download")
 

--- a/tests/cmd/upload/test_upload.py
+++ b/tests/cmd/upload/test_upload.py
@@ -14,24 +14,6 @@ from mobster.cmd.upload.upload import (
 
 
 @pytest.fixture
-def mock_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Set up environment variables needed for the TPA upload command."""
-    monkeypatch.setenv("MOBSTER_TPA_SSO_TOKEN_URL", "https://test.token.url")
-    monkeypatch.setenv("MOBSTER_TPA_SSO_ACCOUNT", "test-account")
-    monkeypatch.setenv("MOBSTER_TPA_SSO_TOKEN", "test-token")
-
-
-@pytest.fixture
-def mock_tpa_client() -> AsyncMock:
-    """Create a mock TPA client that returns success for uploads."""
-    mock = AsyncMock(spec=TPAClient)
-    mock.upload_sbom = AsyncMock(
-        return_value="urn:uuid:12345678-1234-5678-9012-123456789012"
-    )
-    return mock
-
-
-@pytest.fixture
 def mock_oidc_credentials() -> MagicMock:
     return MagicMock(spec=OIDCClientCredentials)
 
@@ -52,10 +34,12 @@ async def test_execute_upload_from_directory(
     mock_oidc: MagicMock,
     mock_tpa_client_class: MagicMock,
     mock_gather_sboms: MagicMock,
-    mock_env_vars: MagicMock,
+    tpa_env_vars: None,
     mock_tpa_client: MagicMock,
 ) -> None:
     """Test uploading SBOMs from a directory."""
+    mock_tpa_client.__aenter__ = AsyncMock(return_value=mock_tpa_client)
+    mock_tpa_client.__aexit__ = AsyncMock(return_value=None)
     mock_tpa_client_class.return_value = mock_tpa_client
     mock_tpa_client.upload_sbom.return_value = (
         "urn:uuid:12345678-1234-5678-9012-123456789012"
@@ -92,10 +76,12 @@ async def test_execute_upload_from_directory(
 async def test_execute_upload_single_file(
     mock_oidc: MagicMock,
     mock_tpa_client_class: MagicMock,
-    mock_env_vars: MagicMock,
+    tpa_env_vars: None,
     mock_tpa_client: MagicMock,
 ) -> None:
     """Test uploading a single SBOM file."""
+    mock_tpa_client.__aenter__ = AsyncMock(return_value=mock_tpa_client)
+    mock_tpa_client.__aexit__ = AsyncMock(return_value=None)
     mock_tpa_client_class.return_value = mock_tpa_client
     mock_tpa_client.upload_sbom.return_value = (
         "urn:uuid:12345678-1234-5678-9012-123456789012"
@@ -136,9 +122,11 @@ async def test_execute_upload_failure(
     mock_oidc: MagicMock,
     mock_tpa_client_class: MagicMock,
     mock_gather_sboms: MagicMock,
-    mock_env_vars: MagicMock,
+    tpa_env_vars: None,
 ) -> None:
     mock_tpa_client = AsyncMock(spec=TPAClient)
+    mock_tpa_client.__aenter__ = AsyncMock(return_value=mock_tpa_client)
+    mock_tpa_client.__aexit__ = AsyncMock(return_value=None)
     # Simulate failure by raising an exception, which will be caught and return False
     mock_tpa_client.upload_sbom = AsyncMock(side_effect=Exception("Upload failed"))
     mock_tpa_client_class.return_value = mock_tpa_client
@@ -171,9 +159,11 @@ async def test_execute_upload_exception(
     mock_oidc: MagicMock,
     mock_tpa_client_class: MagicMock,
     mock_gather_sboms: MagicMock,
-    mock_env_vars: MagicMock,
+    tpa_env_vars: None,
 ) -> None:
     mock_tpa_client = AsyncMock(spec=TPAClient)
+    mock_tpa_client.__aenter__ = AsyncMock(return_value=mock_tpa_client)
+    mock_tpa_client.__aexit__ = AsyncMock(return_value=None)
     mock_tpa_client.upload_sbom = AsyncMock(side_effect=Exception("Upload failed"))
     mock_tpa_client_class.return_value = mock_tpa_client
     mock_oidc.return_value = MagicMock(spec=OIDCClientCredentials)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,9 +8,9 @@ from mobster.main import main, run
 LOGGER = logging.getLogger(__name__)
 
 
-@patch("mobster.main.run")
+@patch("mobster.main.asyncio.run")
 @patch("mobster.main.cli.setup_arg_parser")
-def test_main(mock_setup_args: MagicMock, mock_run: AsyncMock) -> None:
+def test_main(mock_setup_args: MagicMock, mock_asyncio_run: MagicMock) -> None:
     mock_args = mock_setup_args.return_value.parse_args.return_value
     mock_args.verbose = True
     main()
@@ -18,7 +18,7 @@ def test_main(mock_setup_args: MagicMock, mock_run: AsyncMock) -> None:
     mock_setup_args.assert_called_once()
     mock_setup_args.return_value.parse_args.assert_called_once()
 
-    mock_run.assert_called_once()
+    mock_asyncio_run.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -30,6 +30,10 @@ async def test_run(
     mock_args.func = MagicMock()
     mock_args.func.return_value.execute = AsyncMock()
     mock_args.func.return_value.save = AsyncMock()
+    mock_args.func.return_value.name = "test_command"
+
+    # Set logging level to DEBUG to capture the log_elapsed message
+    caplog.set_level(logging.DEBUG)
 
     monkeypatch.setattr("sys.exit", lambda _: None)
     await run(mock_args)


### PR DESCRIPTION
Refactored the TPA client to use a single client for all SBOM uploads to avoid hammering the SSO API and speed up the uploads.

This is just for mobster for now, I will tag the same reviewers on the Bombino PR later.

After this is merged, I will release mobster to pypi with version 1.0.0 as this is a breaking change for users of the TPA client.

Had to quite heavily refactor the unit tests, as they were very implementation-specific. Since this task is just 2SP, I chose to keep roughly their current implementation. They are still bad though and we need to refactor them to be a bit more sensible. I created a story for that, when we need to touch the client again in the future: https://issues.redhat.com/browse/ISV-6321

---
https://issues.redhat.com/browse/ISV-5914