### PR TITLE
test(ISV-6206): A new integration test to vefify SBOM with Conforma

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
 FROM quay.io/konflux-ci/oras:3d83c68 AS oras
 FROM registry.redhat.io/rhtas/cosign-rhel9:1.2.0-1744791100 AS cosign
+FROM quay.io/conforma/cli:snapshot AS conforma
 FROM registry.access.redhat.com/ubi9/python-312@sha256:558341c02c51ee12820185b203edaa953f18d1c2ac4426947547edd9cea44ff0 AS builder
 
 # Set the working directory in the container
@@ -50,6 +51,7 @@ COPY --from=builder /app /app
 # Copy needed binaries for SBOM augmentation
 COPY --from=oras /usr/bin/oras /usr/bin/oras
 COPY --from=cosign /usr/local/bin/cosign /usr/bin/cosign
+COPY --from=conforma /usr/local/bin/ec /usr/bin/ec
 # Copy license to the container
 COPY LICENSE /licenses/
 

--- a/tests/data/integration/Dockerfile.testdata
+++ b/tests/data/integration/Dockerfile.testdata
@@ -1,0 +1,3 @@
+from registry.redhat.io/ubi10:latest
+
+RUN touch a.txt

--- a/tests/data/integration/base_image_digest.txt
+++ b/tests/data/integration/base_image_digest.txt
@@ -1,0 +1,1 @@
+registry.redhat.io/ubi10:latest registry.redhat.io/ubi10:latest@sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740

--- a/tests/data/integration/img_attestation.json
+++ b/tests/data/integration/img_attestation.json
@@ -1,0 +1,3823 @@
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [
+    {
+      "name": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0",
+      "digest": {
+        "sha256": "b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e"
+      }
+    },
+    {
+      "name": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0",
+      "digest": {
+        "sha256": "a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5"
+      }
+    },
+    {
+      "name": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0",
+      "digest": {
+        "sha256": "94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c"
+      }
+    },
+    {
+      "name": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0",
+      "digest": {
+        "sha256": "fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960"
+      }
+    },
+    {
+      "name": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0",
+      "digest": {
+        "sha256": "e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740"
+      }
+    },
+    {
+      "name": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0",
+      "digest": {
+        "sha256": "4a916dbebd3c55fd6298095d39496388f35e69bb52e7623c4f2d1e7f61388c35"
+      }
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v0.2",
+  "predicate": {
+    "buildConfig": {
+      "tasks": [
+        {
+          "finishedOn": "2025-09-24T07:24:18Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "ec962d0be18f36ca7d331c99bf243800f569fc0a2ea6f8c8c3d3a574b71c44dc"
+              },
+              "entryPoint": "init",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-init"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/ca8f8437-b324-468c-8fe3-3cc653ad5066",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-80f8bfbac1ff5a7e-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "init",
+                "tekton.dev/task": "init"
+              }
+            },
+            "parameters": {
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "rebuild": "false",
+              "skip-checks": "false"
+            }
+          },
+          "name": "init",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "init"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:ec962d0be18f36ca7d331c99bf243800f569fc0a2ea6f8c8c3d3a574b71c44dc"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "build",
+              "type": "string",
+              "value": "true"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T07:24:11Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\necho \"Build Initialize: $IMAGE_URL\"\necho\n\nskopeo_retries=3\n\necho \"Determine if Image Already Exists\"\n# Build the image when rebuild is set to true or image does not exist\n# The image check comes last to avoid unnecessary, slow API calls\nif [ \"$REBUILD\" == \"true\" ] || [ \"$SKIP_CHECKS\" == \"false\" ] || ! skopeo inspect --retry-times \"$skopeo_retries\" --no-tags --raw \"docker://$IMAGE_URL\" &>/dev/null; then\n  echo -n \"true\" > /tekton/results/build\nelse\n  echo -n \"false\" > /tekton/results/build\nfi\n",
+              "environment": {
+                "container": "init",
+                "image": "oci://registry.access.redhat.com/ubi9/skopeo@sha256:a65a413f8a2864389a09dc750690d97afbcdc5c70821e0f85e99e8adba7954e0"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "init"
+          ],
+          "finishedOn": "2025-09-24T07:24:27Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "3f1b468066b301083d8550e036f5a654fcb064810bd29eb06fec6d8ad3e35b9c"
+              },
+              "entryPoint": "git-clone-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/bbc97db8-12fe-4aa0-b364-e3e6d7c49e4b",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/categories": "Git",
+                "tekton.dev/displayName": "git clone oci trusted artifacts",
+                "tekton.dev/pipelines.minVersion": "0.21.0",
+                "tekton.dev/platforms": "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64",
+                "tekton.dev/tags": "git",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-a44aeb51e6bafde7-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clone-repository",
+                "tekton.dev/task": "git-clone-oci-ta"
+              }
+            },
+            "parameters": {
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca",
+              "depth": "1",
+              "enableSymlinkCheck": "true",
+              "fetchTags": "false",
+              "httpProxy": "",
+              "httpsProxy": "",
+              "mergeTargetBranch": "false",
+              "noProxy": "",
+              "ociArtifactExpiresAfter": "",
+              "ociStorage": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125.git",
+              "refspec": "",
+              "revision": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "shortCommitLength": "7",
+              "sparseCheckoutDirectories": "",
+              "sslVerify": "true",
+              "submodules": "true",
+              "targetBranch": "main",
+              "url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+              "userHome": "/tekton/home",
+              "verbose": "false"
+            }
+          },
+          "name": "clone-repository",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "git-clone-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:3f1b468066b301083d8550e036f5a654fcb064810bd29eb06fec6d8ad3e35b9c"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "CHAINS-GIT_COMMIT",
+              "type": "string",
+              "value": "15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            },
+            {
+              "name": "CHAINS-GIT_URL",
+              "type": "string",
+              "value": "https://gitlab.com/redhat/rhel/containers/ubi10"
+            },
+            {
+              "name": "commit",
+              "type": "string",
+              "value": "15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            },
+            {
+              "name": "commit-timestamp",
+              "type": "string",
+              "value": "1758672755"
+            },
+            {
+              "name": "short-commit",
+              "type": "string",
+              "value": "15e5733"
+            },
+            {
+              "name": "url",
+              "type": "string",
+              "value": "https://gitlab.com/redhat/rhel/containers/ubi10"
+            },
+            {
+              "name": "SOURCE_ARTIFACT",
+              "type": "string",
+              "value": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:580be3e5bf838042bfa602754d3f65a6534aeb5ddeab195f08e5cd82fd982cd7"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T07:24:19Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env sh\nset -eu\n\nif [ \"${PARAM_VERBOSE}\" = \"true\" ]; then\n  set -x\nfi\n\nif [ \"${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}\" = \"true\" ]; then\n  if [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials\" ] && [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig\" ]; then\n    cp \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials\" \"${PARAM_USER_HOME}/.git-credentials\"\n    cp \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig\" \"${PARAM_USER_HOME}/.gitconfig\"\n  # Compatibility with kubernetes.io/basic-auth secrets\n  elif [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username\" ] && [ -f \"${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password\" ]; then\n    HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')\n    echo \"https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME\" >\"${PARAM_USER_HOME}/.git-credentials\"\n    echo -e \"[credential \\\"https://$HOSTNAME\\\"]\\n  helper = store\" >\"${PARAM_USER_HOME}/.gitconfig\"\n  else\n    echo \"Unknown basic-auth workspace format\"\n    exit 1\n  fi\n  chmod 400 \"${PARAM_USER_HOME}/.git-credentials\"\n  chmod 400 \"${PARAM_USER_HOME}/.gitconfig\"\nfi\n\n# Should be called after the gitconfig is copied from the repository secret\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  git config --global http.sslCAInfo \"$ca_bundle\"\nfi\n\nif [ \"${WORKSPACE_SSH_DIRECTORY_BOUND}\" = \"true\" ]; then\n  cp -R \"${WORKSPACE_SSH_DIRECTORY_PATH}\" \"${PARAM_USER_HOME}\"/.ssh\n  chmod 700 \"${PARAM_USER_HOME}\"/.ssh\n  chmod -R 400 \"${PARAM_USER_HOME}\"/.ssh/*\nfi\n\ntest -z \"${PARAM_HTTP_PROXY}\" || export HTTP_PROXY=\"${PARAM_HTTP_PROXY}\"\ntest -z \"${PARAM_HTTPS_PROXY}\" || export HTTPS_PROXY=\"${PARAM_HTTPS_PROXY}\"\ntest -z \"${PARAM_NO_PROXY}\" || export NO_PROXY=\"${PARAM_NO_PROXY}\"\n\n/ko-app/git-init \\\n  -url=\"${PARAM_URL}\" \\\n  -revision=\"${PARAM_REVISION}\" \\\n  -refspec=\"${PARAM_REFSPEC}\" \\\n  -path=\"${CHECKOUT_DIR}\" \\\n  -sslVerify=\"${PARAM_SSL_VERIFY}\" \\\n  -submodules=\"${PARAM_SUBMODULES}\" \\\n  -depth=\"${PARAM_DEPTH}\" \\\n  -sparseCheckoutDirectories=\"${PARAM_SPARSE_CHECKOUT_DIRECTORIES}\"\ncd \"${CHECKOUT_DIR}\"\nRESULT_SHA=\"$(git rev-parse HEAD)\"\nRESULT_SHA_SHORT=\"$(git rev-parse --short=\"${PARAM_SHORT_COMMIT_LENGTH}\" HEAD)\"\nEXIT_CODE=\"$?\"\nif [ \"${EXIT_CODE}\" != 0 ]; then\n  exit \"${EXIT_CODE}\"\nfi\nif [ \"${PARAM_MERGE_TARGET_BRANCH}\" = \"true\" ]; then\n  echo \"Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA}).\"\n  echo \"Fetching target branch '${PARAM_TARGET_BRANCH}'...\"\n  git fetch origin \"${PARAM_TARGET_BRANCH}\"\n  FETCH_EXIT_CODE=\"$?\"\n  if [ \"${FETCH_EXIT_CODE}\" != \"0\" ]; then\n    echo \"ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'.\" >&2\n    exit \"${FETCH_EXIT_CODE}\"\n  fi\n  echo \"Merging origin/${PARAM_TARGET_BRANCH} into current HEAD...\"\n  git config --global user.email \"tekton-git-clone@tekton.dev\"\n  git config --global user.name \"Tekton Git Clone Task\"\n  git merge \"origin/${PARAM_TARGET_BRANCH}\" --no-commit --no-ff --allow-unrelated-histories\n  MERGE_CHECK_EXIT_CODE=\"$?\"\n  if [ \"${MERGE_CHECK_EXIT_CODE}\" != \"0\" ]; then\n    echo \"ERROR: Merge conflict detected or merge failed before commit.\" >&2\n    echo \"--- Git Status ---\"\n    git status\n    echo \"------------------\"\n    exit \"${MERGE_CHECK_EXIT_CODE}\"\n  else\n    # Check if there are changes that need to be merged, and if so, create a merge commit.\n    if git diff --staged --quiet; then\n      echo \"No diff was found, skipping merge...\" >&2\n    else\n      echo \"Merge successful (no conflicts found), committing...\"\n      git commit -m \"Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}\"\n      COMMIT_EXIT_CODE=\"$?\"\n      if [ \"${COMMIT_EXIT_CODE}\" != \"0\" ]; then\n        echo \"ERROR: Failed to commit merge.\" >&2\n        exit \"${COMMIT_EXIT_CODE}\"\n      fi\n      MERGED_SHA=$(git rev-parse HEAD)\n      echo \"New HEAD after merge: ${MERGED_SHA}\"\n      echo \"${MERGED_SHA}\" >\"/tekton/results/merged_sha\"\n    fi\n  fi\nelse\n  echo \"Merge option disabled. Using checked-out revision ${RESULT_SHA} directly.\"\nfi\nprintf \"%s\" \"${RESULT_SHA}\" >\"/tekton/results/commit\"\nprintf \"%s\" \"${RESULT_SHA}\" >\"/tekton/results/CHAINS-GIT_COMMIT\"\nprintf \"%s\" \"${RESULT_SHA_SHORT}\" >\"/tekton/results/short-commit\"\nprintf \"%s\" \"${PARAM_URL}\" >\"/tekton/results/url\"\nprintf \"%s\" \"${PARAM_URL}\" >\"/tekton/results/CHAINS-GIT_URL\"\nprintf \"%s\" \"$(git log -1 --pretty=%ct)\" >\"/tekton/results/commit-timestamp\"\n\nif [ \"${PARAM_FETCH_TAGS}\" = \"true\" ]; then\n  echo \"Fetching tags\"\n  if ! git fetch --tags; then\n    echo \"Retrying fetch command...\"\n    git fetch --tags\n  fi\nfi\n",
+              "environment": {
+                "container": "clone",
+                "image": "oci://quay.io/konflux-ci/git-clone@sha256:0e92b8a655d7b2eeba6442bbe008c92ad7f21ea23d8ad76cd95d45353338c1e0"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n\ncheck_symlinks() {\n  FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false\n  while read -r symlink; do\n    target=$(readlink -m \"$symlink\")\n    if ! [[ \"$target\" =~ ^$CHECKOUT_DIR ]]; then\n      echo \"The cloned repository contains symlink pointing outside of the cloned repository: $symlink\"\n      FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true\n    fi\n  done < <(find $CHECKOUT_DIR -type l -print)\n  if [ \"$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO\" = true ]; then\n    return 1\n  fi\n}\n\nif [ \"${PARAM_ENABLE_SYMLINK_CHECK}\" = \"true\" ]; then\n  echo \"Running symlink check\"\n  check_symlinks\nfi\n",
+              "environment": {
+                "container": "symlink-check",
+                "image": "oci://quay.io/konflux-ci/git-clone@sha256:0e92b8a655d7b2eeba6442bbe008c92ad7f21ea23d8ad76cd95d45353338c1e0"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": [
+                "create",
+                "--store",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125.git",
+                "/tekton/results/SOURCE_ARTIFACT=/var/workdir/source"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "create-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:1abf94de338e54dd17a0fb84b6d042d1790ede6d1adf235995db5dc1011886f8"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "clone-repository"
+          ],
+          "finishedOn": "2025-09-24T07:38:36Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "098322d6b789824f716f2d9caca1862d4afdc083ebaaee61aadd22a8c179480a"
+              },
+              "entryPoint": "prefetch-dependencies-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/66cc179f-895a-47ce-9cfa-2b924696499c",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "image-build, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-3e7438bb5d7655e5-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "prefetch-dependencies",
+                "tekton.dev/task": "prefetch-dependencies-oci-ta"
+              }
+            },
+            "parameters": {
+              "ACTIVATION_KEY": "activation-key",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:580be3e5bf838042bfa602754d3f65a6534aeb5ddeab195f08e5cd82fd982cd7",
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca",
+              "config-file-content": "---\nrequests_timeout: 1800\n",
+              "dev-package-managers": "false",
+              "input": "[{\"type\": \"rpm\"}]",
+              "log-level": "debug",
+              "ociArtifactExpiresAfter": "",
+              "ociStorage": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125.prefetch",
+              "sbom-type": "spdx"
+            }
+          },
+          "name": "prefetch-dependencies",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "prefetch-dependencies-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:098322d6b789824f716f2d9caca1862d4afdc083ebaaee61aadd22a8c179480a"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "CACHI2_ARTIFACT",
+              "type": "string",
+              "value": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007"
+            },
+            {
+              "name": "SOURCE_ARTIFACT",
+              "type": "string",
+              "value": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T07:24:29Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "if [ -z \"${INPUT}\" ]; then\n  mkdir -p /var/workdir/source\n  mkdir -p /var/workdir/cachi2\n  echo \"true\" >/var/workdir/source/.skip-trusted-artifacts\n  echo \"true\" >/var/workdir/cachi2/.skip-trusted-artifacts\n  echo -n \"${SOURCE_ARTIFACT}\" >/tekton/results/SOURCE_ARTIFACT\n  echo -n \"\" >/tekton/results/CACHI2_ARTIFACT\nfi\n",
+              "environment": {
+                "container": "skip-ta",
+                "image": "oci://registry.access.redhat.com/ubi9/ubi-minimal@sha256:2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:580be3e5bf838042bfa602754d3f65a6534aeb5ddeab195f08e5cd82fd982cd7=/var/workdir/source"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:98641d6162ee305d09927a87c7c8245a77bffb0061aef6ed18f14c1348a77d07"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "if [ -n \"${CONFIG_FILE_CONTENT}\" ]; then\n  # we need to drop 'goproxy_url' for safety reasons until the CLI prefetch tool upstream\n  # decides what the SBOM impact of this configuration option will be:\n  # https://github.com/hermetoproject/hermeto/issues/577\n  yq 'del(.goproxy_url)' <<<\"${CONFIG_FILE_CONTENT}\" >/mnt/config/config.yaml\nfi\n",
+              "environment": {
+                "container": "sanitize-config-file-with-yq",
+                "image": "oci://quay.io/konflux-ci/yq@sha256:7ef2e2f76ca36bdc7eb9203df31f3bce546d1267b969d9bd2691094b88610dbb"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -euo pipefail\n\nRHSM_ORG=\"\"\nRHSM_ACT_KEY=\"\"\nENTITLEMENT_CERT_PATH=\"\"\nENTITLEMENT_CERT_KEY_PATH=\"\"\n\nfunction rhsm_unregister {\n  # best effort:\n  #   - if the system was already successfully unregistered, the command returns 1\n  #   - if unregistering failed/fails, there's not much we can do about it anyway\n  subscription-manager unregister || true\n}\n\nfunction is_json {\n  jq . 2>/dev/null 1>&2 <<<\"$1\"\n}\n\n# The input JSON can be in one of these forms:\n# 1) '[{\"type\": \"gomod\"}, {\"type\": \"bundler\"}]'\n# 2) '{\"packages\": [{\"type\": \"gomod\"}, {\"type\": \"bundler\"}]}'\n# 3) '{\"type\": \"gomod\"}'\nfunction input_json_has_rpm {\n  jq '\n    if (type == \"array\" or type == \"object\") | not then\n      false\n    elif type == \"array\" then\n      any(.[]; .type == \"rpm\")\n    elif has(\"packages\") | not then\n      .type == \"rpm\"\n    elif (.packages | type == \"array\") then\n      any(.packages[]; .type == \"rpm\")\n    else\n      false\n    end' <<<\"$1\"\n}\n\nfunction inject_ssl_opts {\n  input=\"$1\"\n  ssl_options=\"$2\"\n\n  # Check if input is plain string or JSON and if the request specifies RPMs\n  if [ \"$input\" == \"rpm\" ]; then\n    input=\"$(\n      jq -n --argjson ssl \"$ssl_options\" '\n              {\n                type: \"rpm\",\n                options: {\n                  ssl: $ssl\n                }\n              }'\n    )\"\n  elif is_json \"$input\" && [[ $(input_json_has_rpm \"$input\") == true ]]; then\n    # The output JSON may need the SSL options updated for the RPM backend\n    input=\"$(\n      jq \\\n        --argjson ssl \"$ssl_options\" '\n                if type == \"array\" then\n                  map(if .type == \"rpm\" then .options.ssl += $ssl else . end)\n                elif has(\"packages\") then\n                  .packages |= map(if .type == \"rpm\" then .options.ssl += $ssl else . end)\n                else\n                  .options.ssl += $ssl\n                end' \\\n        <<<\"$input\"\n    )\"\n  fi\n  echo \"$input\"\n}\n\nfunction inject_rpm_summary_flag {\n  input=\"$1\"\n\n  if [ \"$input\" == \"rpm\" ]; then\n    input=\"$(jq -n '{type: \"rpm\", include_summary_in_sbom: true}')\"\n\n  elif is_json \"$input\" && [[ $(input_json_has_rpm \"$input\") == true ]]; then\n    input=\"$(jq '\n                if type == \"array\" then\n                  map(\n                    if .type == \"rpm\" and (has(\"include_summary_in_sbom\") | not) then\n                      .include_summary_in_sbom = true\n                    else\n                      .\n                    end)\n\n                elif has(\"packages\") then\n                  .packages |= map(\n                    if .type == \"rpm\" and (has(\"include_summary_in_sbom\") | not) then\n                      .include_summary_in_sbom = true\n                    else\n                      .\n                    end)\n\n                else\n                  if has(\"include_summary_in_sbom\") | not then\n                    .include_summary_in_sbom = true\n                  else\n                    .\n                  end\n\n                end' <<<\"$input\")\"\n  fi\n  echo \"$input\"\n}\n\nfunction retry() {\n  local status\n  local interval=1\n  local retry=0\n  local -r factor=${RETRY_FACTOR:-2}\n  local -r max_tries=${RETRY_MAX_TRIES:-10}\n  while true; do\n    echo \"Executing:\" \"${@}\" >&2\n    \"$@\" 2>/tmp/errors.txt && break\n    status=$?\n    cat /tmp/errors.txt >&2\n    ((retry += 1))\n    if [ $retry -ge \"$max_tries\" ]; then\n      echo \"error: Command failed after ${max_tries} tries with status ${status}\" >&2\n      return $status\n    fi\n\n    echo \"warning: Command failed and will retry, ${retry} try\" >&2\n\n    unauthorized_error=$(grep -ci \"unauthorized\" /tmp/errors.txt)\n    if [ \"$unauthorized_error\" -ne 0 ]; then\n      echo \"error: Unauthorized error, wrong registry credentials provided, won't retry\" >&2\n      return 1\n    fi\n\n    ((interval = interval * factor))\n    sleep \"$interval\"\n  done\n}\n\nif [ -z \"${INPUT}\" ]; then\n  # Confirm input was provided\n  echo \"No prefetch will be performed because no input was provided\"\n  exit 0\nfi\n\nif [ -f /mnt/config/config.yaml ]; then\n  config_flag=--config-file=/mnt/config/config.yaml\nelse\n  config_flag=\"\"\nfi\n\nif [ \"$DEV_PACKAGE_MANAGERS\" = \"true\" ]; then\n  dev_pacman_flag=--dev-package-managers\nelse\n  dev_pacman_flag=\"\"\nfi\n\n# Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml\nif [ \"${WORKSPACE_GIT_AUTH_BOUND}\" = \"true\" ]; then\n  if [ -f \"${WORKSPACE_GIT_AUTH_PATH}/.git-credentials\" ] && [ -f \"${WORKSPACE_GIT_AUTH_PATH}/.gitconfig\" ]; then\n    cp \"${WORKSPACE_GIT_AUTH_PATH}/.git-credentials\" \"${HOME}/.git-credentials\"\n    cp \"${WORKSPACE_GIT_AUTH_PATH}/.gitconfig\" \"${HOME}/.gitconfig\"\n  # Compatibility with kubernetes.io/basic-auth secrets\n  elif [ -f \"${WORKSPACE_GIT_AUTH_PATH}/username\" ] && [ -f \"${WORKSPACE_GIT_AUTH_PATH}/password\" ]; then\n    HOSTNAME=$(cd \"/var/workdir/source\" && git remote get-url origin | awk -F/ '{print $3}')\n    echo \"https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME\" >\"${HOME}/.git-credentials\"\n    echo -e \"[credential \\\"https://$HOSTNAME\\\"]\\n  helper = store\" >\"${HOME}/.gitconfig\"\n  else\n    echo \"Unknown git-basic-auth workspace format\"\n    exit 1\n  fi\n  chmod 400 \"${HOME}/.git-credentials\"\n  chmod 400 \"${HOME}/.gitconfig\"\nfi\n\nif [ \"${WORKSPACE_NETRC_BOUND}\" = \"true\" ]; then\n  cp \"${WORKSPACE_NETRC_PATH}/.netrc\" \"${HOME}/.netrc\"\nfi\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\n# RHSM HANDLING: REGISTER RHSM & PREFETCH CLI CONFIGURATION\nif [ -e /activation-key/org ]; then\n  RHSM_ORG=$(cat /activation-key/org)\n  RHSM_ACT_KEY=$(cat /activation-key/activationkey)\n\n  echo \"Registering with Red Hat subscription manager.\"\n  export RETRY_MAX_TRIES=6\n  if ! retry subscription-manager register --org \"${RHSM_ORG}\" --activationkey \"${RHSM_ACT_KEY}\"; then\n    echo \"Subscription-manager register failed\"\n    exit 1\n  fi\n  unset RETRY_MAX_TRIES\n\n  trap rhsm_unregister EXIT\n\n  entitlement_files=\"$(ls -1 /etc/pki/entitlement/*.pem)\"\n  ENTITLEMENT_CERT_KEY_PATH=\"$(grep -e '-key.pem$' <<<\"$entitlement_files\")\"\n  ENTITLEMENT_CERT_PATH=\"$(grep -v -e '-key.pem$' <<<\"$entitlement_files\")\"\n  CA_BUNDLE_PATH=\"/etc/rhsm/ca/redhat-uep.pem\"\n\n  PREFETCH_SSL_OPTS=\"$(\n    jq -n \\\n      --arg key \"$ENTITLEMENT_CERT_KEY_PATH\" \\\n      --arg cert \"$ENTITLEMENT_CERT_PATH\" \\\n      --arg ca_bundle \"$CA_BUNDLE_PATH\" \\\n      '{client_key: $key, client_cert: $cert, ca_bundle: $ca_bundle}'\n  )\"\n\n  # We need to modify the CLI params in place if we're processing RPMs\n  INPUT=$(inject_ssl_opts \"$INPUT\" \"$PREFETCH_SSL_OPTS\")\nfi\n\nINPUT=$(inject_rpm_summary_flag \"$INPUT\")\n\n# Some repos with go submodules would fail during prefetch dependencies task\n# Forcing fetching tags serves as a workaround\nexport RETRY_MAX_TRIES=2\nWORKSPACE_SOURCE=\"/var/workdir/source\"\nif ! (cd \"$WORKSPACE_SOURCE\" && retry git fetch --tags); then\n  exit 1\nfi\nunset RETRY_MAX_TRIES\n\nhermeto --log-level=\"$LOG_LEVEL\" $config_flag fetch-deps \\\n  $dev_pacman_flag \\\n  --source=\"/var/workdir/source\" \\\n  --output=\"/var/workdir/cachi2/output\" \\\n  --sbom-output-type=\"$SBOM_TYPE\" \\\n  \"${INPUT}\"\n\nhermeto --log-level=\"$LOG_LEVEL\" generate-env \"/var/workdir/cachi2/output\" \\\n  --format env \\\n  --for-output-dir=/cachi2/output \\\n  --output \"/var/workdir/cachi2/cachi2.env\"\n\nhermeto --log-level=\"$LOG_LEVEL\" inject-files \"/var/workdir/cachi2/output\" \\\n  --for-output-dir=/cachi2/output\n\n# NOTE: Compatibility hack, hermeto will create a hermeto.repo when processing RPMs (1 for\n# each architecture) which may break users expecting cachi2.repo\nfind \"/var/workdir/cachi2/output\" \\\n  -type f \\\n  -name hermeto.repo \\\n  -execdir mv {} cachi2.repo \\;\n\n# hack: the OCI generator would delete the function since it doesn't consider trap a \"usage\"\nif false; then\n  rhsm_unregister\nfi\n",
+              "environment": {
+                "container": "prefetch-dependencies",
+                "image": "oci://quay.io/konflux-ci/hermeto@sha256:bd7d43d80dde2fdd82fb9c9952aba9f830b052bcb1e5f3b54d613555b3a2eda7"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": [
+                "create",
+                "--store",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125.prefetch",
+                "/tekton/results/SOURCE_ARTIFACT=/var/workdir/source",
+                "/tekton/results/CACHI2_ARTIFACT=/var/workdir/cachi2"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "create-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:98641d6162ee305d09927a87c7c8245a77bffb0061aef6ed18f14c1348a77d07"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "prefetch-dependencies"
+          ],
+          "finishedOn": "2025-09-24T07:38:42Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "9d5bc8e93a458102ea119c6828a654ae5ee5e9d0aa0ab462f01d2ebac268e737"
+              },
+              "entryPoint": "generate-labels",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-generate-labels"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/8ee49e30-8d2e-44e3-b66f-7e8998545f20",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-45fb8239aa444482-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "generate-labels",
+                "tekton.dev/task": "generate-labels"
+              }
+            },
+            "parameters": {
+              "actual-date-format": "%Y-%m-%dT%H:%M:%SZ",
+              "label-templates": [
+                "release=$ACTUAL_DATE_EPOCH"
+              ],
+              "source-date-epoch": "",
+              "source-date-format": "%Y-%m-%dT%H:%M:%SZ"
+            }
+          },
+          "name": "generate-labels",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "generate-labels"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-generate-labels:0.1@sha256:9d5bc8e93a458102ea119c6828a654ae5ee5e9d0aa0ab462f01d2ebac268e737"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "actual-date",
+              "type": "string",
+              "value": "2025-09-24T07:38:41Z"
+            },
+            {
+              "name": "actual-date-epoch",
+              "type": "string",
+              "value": "1758699521"
+            },
+            {
+              "name": "labels",
+              "type": "array",
+              "value": [
+                "release=1758699521"
+              ]
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T07:38:37Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "--templates",
+                "release=$ACTUAL_DATE_EPOCH"
+              ],
+              "entryPoint": "#!/bin/bash\n\ntemplates=()\nwhile [[ $# -gt 0 ]]; do\n    case $1 in\n        --templates)\n            shift\n            while [[ $# -gt 0 && $1 != --* ]]; do templates+=(\"$1\"); shift; done\n            ;;\n        *)\n            echo \"unexpected argument: $1\" >&2\n            exit 2\n            ;;\n    esac\ndone\n\nACTUAL_DATE_EPOCH=$(date -u +'%s')\nACTUAL_DATE=$(date -u --date=@\"$ACTUAL_DATE_EPOCH\" \"+$ACTUAL_DATE_FORMAT\")\n\nif [ \"$SOURCE_DATE_EPOCH\" == \"\" ]; then\n  SOURCE_DATE_EPOCH=\"$ACTUAL_DATE_EPOCH\"\nfi\nSOURCE_DATE=$(date -u --date=@\"$SOURCE_DATE_EPOCH\" \"+$SOURCE_DATE_FORMAT\")\n\necho -n \"$ACTUAL_DATE\" > \"/tekton/results/actual-date\"\necho -n \"$ACTUAL_DATE_EPOCH\" > \"/tekton/results/actual-date-epoch\"\n\n# Export, so that these are available to the subshell below\nexport ACTUAL_DATE\nexport ACTUAL_DATE_EPOCH\nexport SOURCE_DATE\nexport SOURCE_DATE_EPOCH\n\nprintf \"[]\" > result.json\n\nexport label\nfor template in \"${templates[@]}\"; do\n  echo \"Processing template $template\"\n  label=$(echo \"$template\" | envsubst)\n  echo \"Yielding label $label\"\n  yq -oj -i '. += [strenv(label)]' result.json\ndone\n\necho \"Created the following labels:\"\ntee \"/tekton/results/labels\" < result.json\n",
+              "environment": {
+                "container": "render",
+                "image": "oci://quay.io/konflux-ci/yq@sha256:875f69f9e2172d627bd01aaf7a0d49f67ffebc07fc148ae0d50865e48bd401b9"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "generate-labels",
+            "clone-repository",
+            "prefetch-dependencies",
+            "init"
+          ],
+          "finishedOn": "2025-09-24T07:43:21Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "17a0b093c9e9d21e9e374c60a88eb293a0fa57e4e2b67baf20ccac9735aa20ff"
+              },
+              "entryPoint": "buildah-remote-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/f205793d-8cdc-4d11-98ba-b532a664a20f",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "image-build, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-23abb0b57424f626-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "build.appstudio.redhat.com/build_type": "docker",
+                "build.appstudio.redhat.com/target-platform": "linux-x86_64",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "build-images",
+                "tekton.dev/task": "buildah-remote-oci-ta"
+              }
+            },
+            "parameters": {
+              "ACTIVATION_KEY": "activation-key",
+              "ADDITIONAL_BASE_IMAGES": [ ],
+              "ADDITIONAL_SECRET": "does-not-exist",
+              "ADD_CAPABILITIES": "",
+              "ANNOTATIONS": [ ],
+              "ANNOTATIONS_FILE": "",
+              "BUILDAH_FORMAT": "oci",
+              "BUILD_ARGS": [ ],
+              "BUILD_ARGS_FILE": "",
+              "BUILD_TIMESTAMP": "",
+              "CACHI2_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007",
+              "COMMIT_SHA": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "CONTEXT": ".",
+              "DOCKERFILE": "Dockerfile",
+              "ENTITLEMENT_SECRET": "etc-pki-entitlement",
+              "HERMETIC": "true",
+              "HTTP_PROXY": "",
+              "ICM_KEEP_COMPAT_LOCATION": "true",
+              "IMAGE": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "IMAGE_APPEND_PLATFORM": "true",
+              "IMAGE_EXPIRES_AFTER": "",
+              "INHERIT_BASE_IMAGE_LABELS": "true",
+              "LABELS": [
+                "release=1758699521"
+              ],
+              "NO_PROXY": "",
+              "PLATFORM": "linux/x86_64",
+              "PREFETCH_INPUT": "[{\"type\": \"rpm\"}]",
+              "PRIVILEGED_NESTED": "false",
+              "PROXY_CA_TRUST_CONFIG_MAP_KEY": "ca-bundle.crt",
+              "PROXY_CA_TRUST_CONFIG_MAP_NAME": "proxy-ca-bundle",
+              "SBOM_TYPE": "spdx",
+              "SKIP_SBOM_GENERATION": "false",
+              "SKIP_UNUSED_STAGES": "true",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7",
+              "SOURCE_URL": "",
+              "SQUASH": "false",
+              "STORAGE_DRIVER": "overlay",
+              "TARGET_STAGE": "",
+              "TLSVERIFY": "true",
+              "WORKINGDIR_MOUNT": "",
+              "YUM_REPOS_D_FETCHED": "fetched.repos.d",
+              "YUM_REPOS_D_SRC": "repos.d",
+              "YUM_REPOS_D_TARGET": "/etc/yum.repos.d",
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca"
+            }
+          },
+          "name": "build-images",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "buildah-remote-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:17a0b093c9e9d21e9e374c60a88eb293a0fa57e4e2b67baf20ccac9735aa20ff"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGE_DIGEST",
+              "type": "string",
+              "value": "sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e"
+            },
+            {
+              "name": "IMAGE_REF",
+              "type": "string",
+              "value": "quay.io/araszka/junk:conforma-img-amd64@sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e"
+            },
+            {
+              "name": "IMAGE_URL",
+              "type": "string",
+              "value": "quay.io/araszka/junk:conforma-img-amd64"
+            },
+            {
+              "name": "SBOM_BLOB_URL",
+              "type": "string",
+              "value": "quay.io/araszka/junk@sha256:402d2692b68f063fcc8bf852d20db61cfa8cc53f27ac5c534bfb4f8da9f6447f"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T07:38:43Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7=/var/workdir/source",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007=/var/workdir/cachi2"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:1abf94de338e54dd17a0fb84b6d042d1790ede6d1adf235995db5dc1011886f8"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": [
+                "--build-args",
+                "--labels",
+                "release=1758699521",
+                "--annotations"
+              ],
+              "entryPoint": "#!/bin/bash\nset -e\nset -o verbose\n\necho \"[$(date --utc -Ins)] Prepare connection\"\n\nmkdir -p ~/.ssh\nif [ -e \"/ssh/error\" ]; then\n  #no server could be provisioned\n  cat /ssh/error\n  exit 1\nfi\nexport SSH_HOST=$(cat /ssh/host)\n\nif [ \"$SSH_HOST\" == \"localhost\" ] ; then\n  IS_LOCALHOST=true\n  echo \"Localhost detected; running build in cluster\"\nelif [ -e \"/ssh/otp\" ]; then\n  curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa\n  echo \"\" >> ~/.ssh/id_rsa\nelse\n  cp /ssh/id_rsa ~/.ssh\nfi\n\nmkdir -p scripts\n\nif ! [[ $IS_LOCALHOST ]]; then\n  echo \"[$(date --utc -Ins)] Setup VM\"\n\n  if [[ \"$BUILDAH_HTTP_PROXY\" =~ .+\\.cluster\\.local ]]; then\n    echo \"[$(date --utc -Ins)] Ignoring cluster local proxy for remote build\"\n    unset BUILDAH_HTTP_PROXY BUILDAH_NO_PROXY\n  fi\n\n  chmod 0400 ~/.ssh/id_rsa\n  export BUILD_DIR=$(cat /ssh/user-dir)\n  export SSH_ARGS=\"-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10\"\n  echo \"$BUILD_DIR\"\n  # shellcheck disable=SC2086\n  ssh $SSH_ARGS \"$SSH_HOST\"  mkdir -p \"${BUILD_DIR@Q}/workspaces\" \"${BUILD_DIR@Q}/scripts\" \"${BUILD_DIR@Q}/volumes\"\n\n  PORT_FORWARD=\"\"\n  PODMAN_PORT_FORWARD=\"\"\n  if [ -n \"$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR\" ] ; then\n    PORT_FORWARD=\" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80\"\n    PODMAN_PORT_FORWARD=\" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost\"\n  fi\n\n  echo \"[$(date --utc -Ins)] Rsync data\"\n\n  rsync -razW /shared/ \"$SSH_HOST:$BUILD_DIR/volumes/shared/\"\n  rsync -razW /var/workdir/ \"$SSH_HOST:$BUILD_DIR/volumes/workdir/\"\n  rsync -razW /entitlement/ \"$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/\"\n  rsync -razW /activation-key/ \"$SSH_HOST:$BUILD_DIR/volumes/activation-key/\"\n  rsync -razW /additional-secret/ \"$SSH_HOST:$BUILD_DIR/volumes/additional-secret/\"\n  rsync -razW /mnt/trusted-ca/ \"$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/\"\n  rsync -razW /mnt/proxy-ca-bundle/ \"$SSH_HOST:$BUILD_DIR/volumes/proxy-ca-bundle/\"\n  rsync -razW  \"$HOME/.docker/\" \"$SSH_HOST:$BUILD_DIR/.docker/\"\n  rsync -razW  --mkpath \"/usr/bin/retry\" \"$SSH_HOST:$BUILD_DIR/usr/bin/retry\"\n  rsync -razW  \"/tekton/results/\" \"$SSH_HOST:$BUILD_DIR/results/\"\nfi\nif [ \"${IMAGE_APPEND_PLATFORM}\" == \"true\" ]; then\n  IMAGE=\"${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}\"\n  export IMAGE\nfi\n\ncat >scripts/script-build.sh <<'REMOTESSHEOF'\n#!/bin/bash\nset -euo pipefail\ncd /var/workdir\n\nfunction set_proxy {\n  if [ -n \"${BUILDAH_HTTP_PROXY}\" ]; then\n    echo \"[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}\"\n    export HTTP_PROXY=\"${BUILDAH_HTTP_PROXY}\"\n    export HTTPS_PROXY=\"${BUILDAH_HTTP_PROXY}\"\n    export ALL_PROXY=\"${BUILDAH_HTTP_PROXY}\"\n    if [ -n \"${BUILDAH_NO_PROXY}\" ]; then\n      echo \"[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}\"\n      export NO_PROXY=\"${BUILDAH_NO_PROXY}\"\n    fi\n  fi\n}\n\nfunction unset_proxy {\n  echo \"[$(date --utc -Ins)] Unsetting proxy\"\n  unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY\n}\n\necho \"[$(date --utc -Ins)] Validate context path\"\n\nif [ -z \"$CONTEXT\" ]; then\n  echo \"WARNING: CONTEXT is empty. Defaulting to '.' (the source directory).\" >&2\n  CONTEXT=\".\"\nfi\n\nsource_dir_path=$(realpath \"$SOURCE_CODE_DIR\")\ncontext_dir_path=$(realpath \"$SOURCE_CODE_DIR/$CONTEXT\")\n\ncase \"$context_dir_path\" in\n\"$source_dir_path\" | \"$source_dir_path/\"*)\n  # path is valid, do nothing\n  ;;\n*)\n  echo \"ERROR: The CONTEXT parameter ('$CONTEXT') is invalid because it escapes the source directory.\" >&2\n  echo \"Source path: $source_dir_path\" >&2\n  echo \"Resolved path: $context_dir_path\" >&2\n  exit 1\n  ;;\nesac\n\necho \"[$(date --utc -Ins)] Update CA trust\"\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nproxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt\nupdate_ca_trust=false\n\nif [ -f \"$ca_bundle\" ]; then\n  echo \"[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt\n  update_ca_trust=true\nfi\n\nif [ -f \"$proxy_ca_bundle\" ] && [ -n \"${BUILDAH_HTTP_PROXY}\" ]; then\n  echo \"[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle\"\n  cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt\n  update_ca_trust=true\nfi\n\nif [ \"$update_ca_trust\" = \"true\" ]; then\n  update-ca-trust\nfi\n\necho \"[$(date --utc -Ins)] Prepare Dockerfile\"\n\nif [ -e \"$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\"\nelif [ -e \"$SOURCE_CODE_DIR/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE\"\nelif [ -e \"$DOCKERFILE\" ]; then\n  # Instrumented builds (SAST) use this custom dockerfile step as their base\n  dockerfile_path=\"$DOCKERFILE\"\nelif echo \"$DOCKERFILE\" | grep -q \"^https\\?://\"; then\n  echo \"Fetch Dockerfile from $DOCKERFILE\"\n  dockerfile_path=$(mktemp --suffix=-Dockerfile)\n  http_code=$(curl -s -S -L -w \"%{http_code}\" --output \"$dockerfile_path\" \"$DOCKERFILE\")\n  if [ \"$http_code\" != 200 ]; then\n    echo \"No Dockerfile is fetched. Server responds $http_code\"\n    exit 1\n  fi\n  http_code=$(curl -s -S -L -w \"%{http_code}\" --output \"$dockerfile_path.dockerignore.tmp\" \"$DOCKERFILE.dockerignore\")\n  if [ \"$http_code\" = 200 ]; then\n    echo \"Fetched .dockerignore from $DOCKERFILE.dockerignore\"\n    mv \"$dockerfile_path.dockerignore.tmp\" \"$SOURCE_CODE_DIR/$CONTEXT/.dockerignore\"\n  fi\nelse\n  echo \"Cannot find Dockerfile $DOCKERFILE\"\n  exit 1\nfi\n\ndockerfile_copy=$(mktemp --tmpdir \"$(basename \"$dockerfile_path\").XXXXXX\")\ncp \"$dockerfile_path\" \"$dockerfile_copy\"\n\n# Inject the image content manifest into the container we are producing.\n# This will generate the content-sets.json file and copy it by appending a COPY\n# instruction to the Containerfile.\nicm_opts=()\nif [ \"${ICM_KEEP_COMPAT_LOCATION}\" = \"true\" ]; then\n  icm_opts+=(-c)\nfi\ninject-icm-to-containerfile \"${icm_opts[@]}\" \"$dockerfile_copy\" \"/var/workdir/cachi2/output/bom.json\" \"$SOURCE_CODE_DIR/$CONTEXT\"\n\necho \"[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))\"\n\n# Fixing group permission on /var/lib/containers\nchown root:root /var/lib/containers\n\nsed -i 's/^\\s*short-name-mode\\s*=\\s*.*/short-name-mode = \"disabled\"/' /etc/containers/registries.conf\n\n# Setting new namespace to run buildah - 2^32-2\necho 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid\n\nbuild_args=()\nif [ -n \"${BUILD_ARGS_FILE}\" ]; then\n  # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it\n  echo \"Parsing ARGs from $BUILD_ARGS_FILE\"\n  mapfile -t build_args < <(\n    # https://www.mankier.com/1/buildah-build#--build-arg-file\n    # delete lines that start with #\n    # delete blank lines\n    sed -e '/^#/d' -e '/^\\s*$/d' \"${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}\"\n  )\nfi\n\nLABELS=()\nANNOTATIONS=()\n# Append any annotations from the specified file\nif [ -n \"${ANNOTATIONS_FILE}\" ] && [ -f \"${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}\" ]; then\n  echo \"Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}\"\n  while IFS= read -r line || [[ -n \"$line\" ]]; do\n    # Skip empty lines and comments\n    if [[ -n \"$line\" && ! \"$line\" =~ ^[[:space:]]*# ]]; then\n      ANNOTATIONS+=(\"--annotation\" \"$line\")\n    fi\n  done <\"${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}\"\nfi\n\n# Split `args` into two sets of arguments.\nwhile [[ $# -gt 0 ]]; do\n  case $1 in\n  --build-args)\n    shift\n    # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being\n    # passed to buildah. In that case, the *last* occurrence takes precedence. This is why\n    # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE\n    while [[ $# -gt 0 && $1 != --* ]]; do\n      build_args+=(\"$1\")\n      shift\n    done\n    ;;\n  --labels)\n    shift\n    while [[ $# -gt 0 && $1 != --* ]]; do\n      LABELS+=(\"--label\" \"$1\")\n      shift\n    done\n    ;;\n  --annotations)\n    shift\n    while [[ $# -gt 0 && $1 != --* ]]; do\n      ANNOTATIONS+=(\"--annotation\" \"$1\")\n      shift\n    done\n    ;;\n  *)\n    echo \"unexpected argument: $1\" >&2\n    exit 2\n    ;;\n  esac\ndone\n\nBUILD_ARG_FLAGS=()\nfor build_arg in \"${build_args[@]}\"; do\n  BUILD_ARG_FLAGS+=(\"--build-arg=$build_arg\")\ndone\n\n# Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually\nBUILDAH_INFO=$(buildah info)\nBUILDAH_OS=$(jq -r '.host.os' <<<\"$BUILDAH_INFO\")\nBUILDAH_ARCH=$(jq -r '.host.arch' <<<\"$BUILDAH_INFO\")\nBUILDAH_VARIANT=$(jq -r '.host.variant' <<<\"$BUILDAH_INFO\")\nBUILDAH_PLATFORM=\"${BUILDAH_OS}/${BUILDAH_ARCH}\"\n\nDOCKERFILE_ARG_FLAGS=()\n\n# Reference for variables:\n# https://docs.docker.com/build/building/variables/#pre-defined-build-arguments\nPREFIXES=('BUILD' 'TARGET')\nfor PREFIX in \"${PREFIXES[@]}\"; do\n  DOCKERFILE_ARG_FLAGS+=(\"--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}\")\n  DOCKERFILE_ARG_FLAGS+=(\"--build-arg=${PREFIX}OS=${BUILDAH_OS}\")\n  DOCKERFILE_ARG_FLAGS+=(\"--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}\")\n  DOCKERFILE_ARG_FLAGS+=(\"--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}\")\ndone\n\nDOCKERFILE_ARG_FLAGS+=(\"${BUILD_ARG_FLAGS[@]}\")\n\ndockerfile-json \"${DOCKERFILE_ARG_FLAGS[@]}\" \"$dockerfile_copy\" >/shared/parsed_dockerfile.json\nBASE_IMAGES=$(\n  jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test(\"^oci-archive:\") | not)' /shared/parsed_dockerfile.json |\n    tr -d '\"' |\n    tr -d \"'\"\n)\n\nBUILDAH_ARGS=()\nUNSHARE_ARGS=()\n\nif [ \"${HERMETIC}\" == \"true\" ]; then\n  BUILDAH_ARGS+=(\"--pull=never\")\n  UNSHARE_ARGS+=(\"--net\")\n  buildah_retries=3\n\n  set_proxy\n\n  for image in $BASE_IMAGES; do\n    if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry \"$buildah_retries\" \"$image\"; then\n      echo \"Failed to pull base image ${image}\"\n      exit 1\n    fi\n  done\n\n  unset_proxy\n\n  echo \"Build will be executed with network isolation\"\nfi\n\nif [ -n \"${TARGET_STAGE}\" ]; then\n  BUILDAH_ARGS+=(\"--target=${TARGET_STAGE}\")\nfi\n\nBUILDAH_ARGS+=(\"${BUILD_ARG_FLAGS[@]}\")\n\n# Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux\n# TODO remove the option once all hosts were updated\nBUILDAH_ARGS+=(\"--security-opt=unmask=/proc/interrupts\")\n\nif [ \"${PRIVILEGED_NESTED}\" == \"true\" ]; then\n  BUILDAH_ARGS+=(\"--security-opt=label=disable\")\n  BUILDAH_ARGS+=(\"--cap-add=all\")\n  BUILDAH_ARGS+=(\"--device=/dev/fuse\")\nfi\n\nif [ -n \"${ADD_CAPABILITIES}\" ]; then\n  BUILDAH_ARGS+=(\"--cap-add=${ADD_CAPABILITIES}\")\nfi\n\nif [ \"${SQUASH}\" == \"true\" ]; then\n  BUILDAH_ARGS+=(\"--squash\")\nfi\n\nif [ \"${SKIP_UNUSED_STAGES}\" != \"true\" ]; then\n  BUILDAH_ARGS+=(\"--skip-unused-stages=false\")\nfi\n\nif [ \"${INHERIT_BASE_IMAGE_LABELS}\" != \"true\" ]; then\n  BUILDAH_ARGS+=(\"--inherit-labels=false\")\nfi\n\nVOLUME_MOUNTS=()\n\necho \"[$(date --utc -Ins)] Setup prefetched\"\n\nif [ -f \"/var/workdir/cachi2/cachi2.env\" ]; then\n  cp -r \"/var/workdir/cachi2\" /tmp/\n  chmod -R go+rwX /tmp/cachi2\n  VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)\n  # Read in the whole file (https://unix.stackexchange.com/questions/533277), then\n  # for each RUN ... line insert the cachi2.env command *after* any options like --mount\n  sed -E -i \\\n    -e 'H;1h;$!d;x' \\\n    -e 's@^\\s*(run((\\s|\\\\\\n)+-\\S+)*(\\s|\\\\\\n)+)@\\1. /cachi2/cachi2.env \\&\\& \\\\\\n    @igM' \\\n    \"$dockerfile_copy\"\n  echo \"Prefetched content will be made available\"\n\n  prefetched_repo_for_my_arch=\"/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo\"\n  if [ -f \"$prefetched_repo_for_my_arch\" ]; then\n    echo \"Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED\"\n    mkdir -p \"$YUM_REPOS_D_FETCHED\"\n    if [ ! -f \"${YUM_REPOS_D_FETCHED}/cachi2.repo\" ]; then\n      cp \"$prefetched_repo_for_my_arch\" \"$YUM_REPOS_D_FETCHED\"\n    fi\n  fi\nfi\n\n# if yum repofiles stored in git, copy them to mount point outside the source dir\nif [ -d \"${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}\" ]; then\n  mkdir -p \"${YUM_REPOS_D_FETCHED}\"\n  cp -r \"${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}\"/* \"${YUM_REPOS_D_FETCHED}\"\nfi\n\n# if anything in the repofiles mount point (either fetched or from git), mount it\nif [ -d \"${YUM_REPOS_D_FETCHED}\" ]; then\n  chmod -R go+rwX \"${YUM_REPOS_D_FETCHED}\"\n  mount_point=$(realpath \"${YUM_REPOS_D_FETCHED}\")\n  VOLUME_MOUNTS+=(--volume \"${mount_point}:${YUM_REPOS_D_TARGET}\")\nfi\n\nDEFAULT_LABELS=(\n  \"--label\" \"architecture=$(uname -m)\"\n  \"--label\" \"vcs-type=git\"\n)\nif [ -n \"$COMMIT_SHA\" ]; then\n  DEFAULT_LABELS+=(\"--label\" \"vcs-ref=${COMMIT_SHA}\" \"--label\" \"org.opencontainers.image.revision=${COMMIT_SHA}\")\n  ANNOTATIONS+=(\"--annotation\" \"org.opencontainers.image.revision=${COMMIT_SHA}\")\nfi\nif [ -n \"$SOURCE_URL\" ]; then\n  DEFAULT_LABELS+=(\"--label\" \"org.opencontainers.image.source=${SOURCE_URL}\")\n  ANNOTATIONS+=(\"--annotation\" \"org.opencontainers.image.source=${SOURCE_URL}\")\nfi\n[ -n \"$IMAGE_EXPIRES_AFTER\" ] && DEFAULT_LABELS+=(\"--label\" \"quay.expires-after=$IMAGE_EXPIRES_AFTER\")\nBUILD_TIMESTAMP_RFC3339=\"\"\nif [ -n \"$BUILD_TIMESTAMP\" ]; then\n  BUILD_TIMESTAMP_RFC3339=$(date -u -d \"@$BUILD_TIMESTAMP\" +'%Y-%m-%dT%H:%M:%SZ')\n  DEFAULT_LABELS+=(\"--label\" \"build-date=${BUILD_TIMESTAMP_RFC3339}\")\n  DEFAULT_LABELS+=(\"--label\" \"org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}\")\n  ANNOTATIONS+=(\"--annotation\" \"org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}\")\nelse\n  DEFAULT_LABELS+=(\"--label\" \"build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')\")\nfi\n\nlabel_pairs=()\n# If INHERIT_BASE_IMAGE_LABELS is true, get the labels from the final base image only\ntouch base_images_labels.json\nif [[ \"$INHERIT_BASE_IMAGE_LABELS\" == \"true\" ]] && [[ -n \"$BASE_IMAGES\" ]]; then\n  FINAL_BASE_IMAGE=$(\n    # Get the base image of the final stage\n    # The final stage can refer to a previous `FROM xxx AS yyy` stage, for example 'FROM bar AS foo; ... ; FROM foo; ...'\n    # Define a function that keeps nesting recursively into the parent stages until it finds the original base image\n    # Run the find_root_stage() function on the final stage\n    # If the final stage is scratch or oci-archive, return empty\n    jq -r '.Stages as $all_stages |\n      def find_root_stage($stage):\n        if $stage.From.Stage then\n          find_root_stage($all_stages[$stage.From.Stage.Index])\n        else\n          $stage\n        end;\n\n        find_root_stage(.Stages[-1]) |\n        if .From.Scratch or (.BaseName | test(\"^oci-archive:\")) then\n          empty\n        else\n          .BaseName\n        end' /shared/parsed_dockerfile.json |\n      tr -d '\"' |\n      tr -d \"'\"\n  )\n  if [[ -n \"$FINAL_BASE_IMAGE\" ]]; then\n    buildah pull \"$FINAL_BASE_IMAGE\" >/dev/null$()\n    buildah inspect \"$FINAL_BASE_IMAGE\" | jq '.OCIv1.config.Labels' >\"base_images_labels.json\"\n  fi\nfi\n\n# Concatenate defaults and explicit labels. If a label appears twice, the last one wins.\nLABELS=(\"${DEFAULT_LABELS[@]}\" \"${LABELS[@]}\")\n\n# Get all the default and explicit labels so that they can be written into labels.json\nfor label in \"${LABELS[@]}\"; do\n  if [[ \"$label\" != \"--label\" ]]; then\n    label_pairs+=(\"$label\")\n  fi\ndone\n\n# Labels that we explicitly add to the image\n[ -n \"$BUILD_TIMESTAMP_RFC3339\" ] && label_pairs+=(\"org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}\")\nlabel_pairs+=(\"io.buildah.version=$(buildah version --json | jq -r '.version')\")\n\nwhile IFS= read -r label; do\n  label_pairs+=(\"$label\")\ndone < <(jq -r '.Stages[].Commands[] | select(.Name == \"LABEL\") | .Labels[] | \"\\(.Key)=\\(.Value)\"' /shared/parsed_dockerfile.json | sed 's/\"//g')\n\nprintf '%s\\n' \"${label_pairs[@]}\" | jq -Rn '\n  [ inputs | select(length>0) ]\n| map( split(\"=\") | {(.[0]): (.[1] // \"\")} )\n  | add' >\"image_labels.json\"\n\njq -s '(.[0] // {}) * (.[1] // {})' \"base_images_labels.json\" \"image_labels.json\" >\"$SOURCE_CODE_DIR/$CONTEXT/labels.json\"\n\njq '.' \"$SOURCE_CODE_DIR/$CONTEXT/labels.json\"\n\necho \"\" >>\"$dockerfile_copy\"\necho 'COPY labels.json /root/buildinfo/labels.json' >>\"$dockerfile_copy\"\n\n# Make sure our labels.json file isn't filtered out\ncontainerignore=\"\"\nif [ -f \"$SOURCE_CODE_DIR/$CONTEXT/.containerignore\" ]; then\n  containerignore=\"$SOURCE_CODE_DIR/$CONTEXT/.containerignore\"\nelif [ -f \"$SOURCE_CODE_DIR/$CONTEXT/.dockerignore\" ]; then\n  containerignore=\"$SOURCE_CODE_DIR/$CONTEXT/.dockerignore\"\nfi\n\nif [ -n \"$containerignore\" ]; then\n  ignorefile_copy=$(mktemp --tmpdir \"$(basename \"$containerignore\").XXXXXX\")\n  cp \"$containerignore\" \"$ignorefile_copy\"\n\n  echo \"\" >>\"$ignorefile_copy\"\n  echo \"!/labels.json\" >>\"$ignorefile_copy\"\n  BUILDAH_ARGS+=(--ignorefile \"$ignorefile_copy\")\nfi\n\necho \"[$(date --utc -Ins)] Register sub-man\"\n\nACTIVATION_KEY_PATH=\"/activation-key\"\nENTITLEMENT_PATH=\"/entitlement\"\n\n# 0. if hermetic=true, skip all subscription related stuff\n# 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.\n# 2. Activation-keys will be used when the key 'org' exists in the activation key secret.\n# 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.\n# 3. If the Dockerfile contains the string \"subcription-manager register\", add the activation-keys volume\n#    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on\n#    shared emptydir volume to \"/etc/pki/entitlement\" to prevent certificates from being included\n\nif [ \"${HERMETIC}\" != \"true\" ] && [ -e /activation-key/org ]; then\n  cp -r --preserve=mode \"$ACTIVATION_KEY_PATH\" /tmp/activation-key\n  mkdir -p /shared/rhsm/etc/pki/entitlement\n  mkdir -p /shared/rhsm/etc/pki/consumer\n\n  VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key\n    -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z\n    -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)\n  echo \"Adding activation key to the build\"\n\n  if ! grep -E \"^[^#]*subscription-manager.[^#]*register\" \"$dockerfile_path\"; then\n    # user is not running registration in the Containerfile: pre-register.\n    echo \"Pre-registering with subscription manager.\"\n    export RETRY_MAX_TRIES=6\n    if ! retry subscription-manager register --org \"$(cat /tmp/activation-key/org)\" --activationkey \"$(cat /tmp/activation-key/activationkey)\"; then\n      echo \"Subscription-manager register failed\"\n      exit 1\n    fi\n    unset RETRY_MAX_TRIES\n    trap 'subscription-manager unregister || true' EXIT\n\n    # copy generated certificates to /shared volume\n    cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement\n    cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer\n\n    # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca\n    VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)\n  fi\n\nelif [ \"${HERMETIC}\" != \"true\" ] && find /entitlement -name \"*.pem\" >>null; then\n  cp -r --preserve=mode \"$ENTITLEMENT_PATH\" /tmp/entitlement\n  VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)\n  echo \"Adding the entitlement to the build\"\nfi\n\nif [ -n \"$WORKINGDIR_MOUNT\" ]; then\n  if [[ \"$WORKINGDIR_MOUNT\" == *:* ]]; then\n    echo \"WORKINGDIR_MOUNT contains ':'\" >&2\n    echo \"Refusing to proceed in case this is an attempt to set unexpected mount options.\" >&2\n    exit 1\n  fi\n  # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'\n  # (we set the workdir using 'unshare -w')\n  context_dir=$(realpath \"${SOURCE_CODE_DIR}/${CONTEXT}\")\n  VOLUME_MOUNTS+=(--volume \"$context_dir:${WORKINGDIR_MOUNT}\")\nfi\n\nif [ -n \"${ADDITIONAL_VOLUME_MOUNTS-}\" ]; then\n  # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.\n  # Instrumented builds (SAST) use this step as their base and add some other tools.\n  while read -r volume_mount; do\n    VOLUME_MOUNTS+=(\"--volume=$volume_mount\")\n  done <<<\"$ADDITIONAL_VOLUME_MOUNTS\"\nfi\n\necho \"[$(date --utc -Ins)] Add secrets\"\n\nADDITIONAL_SECRET_PATH=\"/additional-secret\"\nADDITIONAL_SECRET_TMP=\"/tmp/additional-secret\"\nif [ -d \"$ADDITIONAL_SECRET_PATH\" ]; then\n  cp -r --preserve=mode -L \"$ADDITIONAL_SECRET_PATH\" $ADDITIONAL_SECRET_TMP\n  while read -r filename; do\n    echo \"Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}\"\n    BUILDAH_ARGS+=(\"--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}\")\n  done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \\;)\nfi\n\n# Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.\ndeclare IMAGE\n\nbuildah_cmd_array=(\n  buildah build\n  \"${VOLUME_MOUNTS[@]}\"\n  \"${BUILDAH_ARGS[@]}\"\n  \"${LABELS[@]}\"\n  \"${ANNOTATIONS[@]}\"\n  --tls-verify=\"$TLSVERIFY\" --no-cache\n  --ulimit nofile=4096:4096\n  --http-proxy=false\n  -f \"$dockerfile_copy\" -t \"$IMAGE\" .\n)\nbuildah_cmd=$(printf \"%q \" \"${buildah_cmd_array[@]}\")\n\nif [ \"${HERMETIC}\" == \"true\" ]; then\n  # enabling loopback adapter enables Bazel builds to work in hermetic mode.\n  command=\"ip link set lo up && $buildah_cmd\"\nelse\n  command=\"$buildah_cmd\"\nfi\n\n# disable host subcription manager integration\nfind /usr/share/rhel/secrets -type l -exec unlink {} \\;\n\nset_proxy\n\necho \"[$(date --utc -Ins)] Run buildah build\"\necho \"[$(date --utc -Ins)] ${command}\"\n\nunshare -Uf \"${UNSHARE_ARGS[@]}\" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w \"${SOURCE_CODE_DIR}/$CONTEXT\" --mount -- sh -c \"$command\"\n\nunset_proxy\n\necho \"[$(date --utc -Ins)] Add metadata\"\n\n# Save the SBOM produced in prefetch so it can be merged into the final SBOM later\nif [ -f \"/tmp/cachi2/output/bom.json\" ]; then\n  echo \"Making copy of sbom-prefetch.json\"\n  cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json\nfi\n\ntouch /shared/base_images_digests\necho \"Recording base image digests used\"\nfor image in $BASE_IMAGES; do\n  # Get the image pullspec and filter out a tag if it is not set\n  base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag \"<none>\" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference=\"$image\")\n  # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens\n  # if buildah did not use that particular image during build because it was skipped\n  if [ -n \"$base_image_digest\" ]; then\n    echo \"$image $base_image_digest\" | tee -a /shared/base_images_digests\n  fi\ndone\n\nimage_name=$(echo \"${IMAGE##*/}\" | tr ':' '-')\nbuildah push \"$IMAGE\" oci:\"/shared/$image_name.oci\"\necho \"/shared/$image_name.oci\" >/shared/container_path\n\necho \"[$(date --utc -Ins)] End build\"\n\nbuildah push \"$IMAGE\" \"oci:konflux-final-image:$IMAGE\"\necho \"[$(date --utc -Ins)] End push remote\"\nREMOTESSHEOF\nchmod +x scripts/script-build.sh\n\nPODMAN_NVIDIA_ARGS=()\nif [[ \"$PLATFORM\" == \"linux-g\"* ]]; then\n    PODMAN_NVIDIA_ARGS+=(\"--device=nvidia.com/gpu=all\" \"--security-opt=label=disable\")\nfi\n\nif ! [[ $IS_LOCALHOST ]]; then\n  PRIVILEGED_NESTED_FLAGS=()\n  if [[ \"${PRIVILEGED_NESTED}\" == \"true\" ]]; then\n    # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.\n    # https://github.com/coreos/rpm-ostree/discussions/4648\n    # shellcheck disable=SC2086\n    ssh $SSH_ARGS \"$SSH_HOST\"  mkdir -p \"${BUILD_DIR@Q}/var/tmp\"\n    PRIVILEGED_NESTED_FLAGS=(--privileged --mount \"type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared\")\n  fi\n  rsync -ra scripts \"$SSH_HOST:$BUILD_DIR\"\n  echo \"[$(date --utc -Ins)] Build via ssh\"\n  # shellcheck disable=SC2086\n  # Please note: all variables below the first ssh line must be quoted with ${var@Q}!\n  # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \\\n    --tmpfs /run/secrets \\\n    -e ACTIVATION_KEY=\"${ACTIVATION_KEY@Q}\" \\\n    -e ADDITIONAL_SECRET=\"${ADDITIONAL_SECRET@Q}\" \\\n    -e ADD_CAPABILITIES=\"${ADD_CAPABILITIES@Q}\" \\\n    -e ANNOTATIONS_FILE=\"${ANNOTATIONS_FILE@Q}\" \\\n    -e BUILD_ARGS_FILE=\"${BUILD_ARGS_FILE@Q}\" \\\n    -e BUILD_TIMESTAMP=\"${BUILD_TIMESTAMP@Q}\" \\\n    -e CONTEXT=\"${CONTEXT@Q}\" \\\n    -e ENTITLEMENT_SECRET=\"${ENTITLEMENT_SECRET@Q}\" \\\n    -e HERMETIC=\"${HERMETIC@Q}\" \\\n    -e IMAGE=\"${IMAGE@Q}\" \\\n    -e IMAGE_EXPIRES_AFTER=\"${IMAGE_EXPIRES_AFTER@Q}\" \\\n    -e INHERIT_BASE_IMAGE_LABELS=\"${INHERIT_BASE_IMAGE_LABELS@Q}\" \\\n    -e PRIVILEGED_NESTED=\"${PRIVILEGED_NESTED@Q}\" \\\n    -e SBOM_TYPE=\"${SBOM_TYPE@Q}\" \\\n    -e SKIP_SBOM_GENERATION=\"${SKIP_SBOM_GENERATION@Q}\" \\\n    -e SKIP_UNUSED_STAGES=\"${SKIP_UNUSED_STAGES@Q}\" \\\n    -e SOURCE_CODE_DIR=\"${SOURCE_CODE_DIR@Q}\" \\\n    -e SQUASH=\"${SQUASH@Q}\" \\\n    -e STORAGE_DRIVER=\"${STORAGE_DRIVER@Q}\" \\\n    -e TARGET_STAGE=\"${TARGET_STAGE@Q}\" \\\n    -e TLSVERIFY=\"${TLSVERIFY@Q}\" \\\n    -e WORKINGDIR_MOUNT=\"${WORKINGDIR_MOUNT@Q}\" \\\n    -e YUM_REPOS_D_FETCHED=\"${YUM_REPOS_D_FETCHED@Q}\" \\\n    -e YUM_REPOS_D_SRC=\"${YUM_REPOS_D_SRC@Q}\" \\\n    -e YUM_REPOS_D_TARGET=\"${YUM_REPOS_D_TARGET@Q}\" \\\n    -e COMMIT_SHA=\"${COMMIT_SHA@Q}\" \\\n    -e SOURCE_URL=\"${SOURCE_URL@Q}\" \\\n    -e DOCKERFILE=\"${DOCKERFILE@Q}\" \\\n    -e BUILDAH_HTTP_PROXY=\"${BUILDAH_HTTP_PROXY@Q}\" \\\n    -e BUILDAH_NO_PROXY=\"${BUILDAH_NO_PROXY@Q}\" \\\n    -e ICM_KEEP_COMPAT_LOCATION=\"${ICM_KEEP_COMPAT_LOCATION@Q}\" \\\n    -v \"${BUILD_DIR@Q}/volumes/shared:/shared:Z\" \\\n    -v \"${BUILD_DIR@Q}/volumes/workdir:/var/workdir:Z\" \\\n    -v \"${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z\" \\\n    -v \"${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z\" \\\n    -v \"${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z\" \\\n    -v \"${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z\" \\\n    -v \"${BUILD_DIR@Q}/volumes/proxy-ca-bundle:/mnt/proxy-ca-bundle:Z\" \\\n    -v \"${BUILD_DIR@Q}/.docker/:/root/.docker:Z\" \\\n    -v \"${BUILD_DIR@Q}/usr/bin/retry:/usr/bin/retry:Z\" \\\n    -v \"${BUILD_DIR@Q}/results/:/tekton/results:Z\" \\\n    -v \"${BUILD_DIR@Q}/scripts:/scripts:Z\" \\\n    \"${PRIVILEGED_NESTED_FLAGS[@]@Q}\" \\\n    --user=0 \"${PODMAN_NVIDIA_ARGS[@]@Q}\" --rm \"${BUILDER_IMAGE@Q}\" /scripts/script-build.sh \"${@@Q}\"\n  echo \"[$(date --utc -Ins)] Rsync back\"\n  rsync -razW --stats \"$SSH_HOST:$BUILD_DIR/volumes/shared/\" /shared/\n  rsync -razW --stats \"$SSH_HOST:$BUILD_DIR/volumes/workdir/\" /var/workdir/\n  rsync -razW --stats \"$SSH_HOST:$BUILD_DIR/results/\" \"/tekton/results/\"\n  echo \"[$(date --utc -Ins)] Buildah pull\"\n  buildah pull \"oci:konflux-final-image:$IMAGE\"\nelse\n  bash scripts/script-build.sh \"$@\"\nfi\necho \"Build on remote host $SSH_HOST finished\"\n\necho \"[$(date --utc -Ins)] Final touches\"\n\nbuildah images\necho \"[$(date --utc -Ins)] End remote\"",
+              "environment": {
+                "container": "build",
+                "image": "oci://quay.io/konflux-ci/buildah-task@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -e\nif [ \"${IMAGE_APPEND_PLATFORM}\" == \"true\" ]; then\n  IMAGE=\"${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}\"\n  export IMAGE\nfi\n\necho \"[$(date --utc -Ins)] Update CA trust\"\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\necho \"[$(date --utc -Ins)] Convert image\"\n\n# While we can build images with the desired format, we will simplify any local\n# and remote build differences by just performing any necessary conversions at\n# push time.\npush_format=oci\nif [ \"${BUILDAH_FORMAT}\" == \"docker\" ]; then\n  push_format=docker\nfi\n\necho \"[$(date --utc -Ins)] Push image with unique tag\"\n\nbuildah_retries=3\n\n# Push to a unique tag based on the TaskRun name to avoid race conditions\necho \"Pushing to ${IMAGE%:*}:${TASKRUN_NAME}\"\nif ! retry buildah push \\\n  --format=\"$push_format\" \\\n  --retry \"$buildah_retries\" \\\n  --tls-verify=\"$TLSVERIFY\" \\\n  \"$IMAGE\" \\\n  \"docker://${IMAGE%:*}:${TASKRUN_NAME}\"; then\n  echo \"Failed to push sbom image to ${IMAGE%:*}:${TASKRUN_NAME}\"\n  exit 1\nfi\n\necho \"[$(date --utc -Ins)] Push image with git revision\"\n\n# Push to a tag based on the git revision\necho \"Pushing to ${IMAGE}\"\nif ! retry buildah push \\\n  --format=\"$push_format\" \\\n  --retry \"$buildah_retries\" \\\n  --tls-verify=\"$TLSVERIFY\" \\\n  --digestfile \"/var/workdir/image-digest\" \"$IMAGE\" \\\n  \"docker://$IMAGE\"; then\n  echo \"Failed to push sbom image to $IMAGE\"\n  exit 1\nfi\n\ncat \"/var/workdir\"/image-digest | tee /tekton/results/IMAGE_DIGEST\necho -n \"$IMAGE\" | tee /tekton/results/IMAGE_URL\n{\n  echo -n \"${IMAGE}@\"\n  cat \"/var/workdir/image-digest\"\n} >\"/tekton/results/IMAGE_REF\"\n\necho\necho \"[$(date --utc -Ins)] End push\"\n",
+              "environment": {
+                "container": "push",
+                "image": "oci://quay.io/konflux-ci/buildah-task@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -e\nif [ \"${IMAGE_APPEND_PLATFORM}\" == \"true\" ]; then\n  IMAGE=\"${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}\"\n  export IMAGE\nfi\necho \"[$(date --utc -Ins)] Generate SBOM\"\n\nif [ \"${SKIP_SBOM_GENERATION}\" = \"true\" ]; then\n  echo \"Skipping SBOM generation\"\n  exit 0\nfi\n\ncase $SBOM_TYPE in\ncyclonedx)\n  syft_sbom_type=cyclonedx-json@1.5\n  ;;\nspdx)\n  syft_sbom_type=spdx-json@2.3\n  ;;\n*)\n  echo \"Invalid SBOM type: $SBOM_TYPE. Valid: cyclonedx, spdx\" >&2\n  exit 1\n  ;;\nesac\n\necho \"Running syft on the source directory\"\nsyft dir:\"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT\" --output \"$syft_sbom_type\"=\"/var/workdir/sbom-source.json\"\necho \"Running syft on the image\"\nsyft oci-dir:\"$(cat /shared/container_path)\" --output \"$syft_sbom_type\"=\"/var/workdir/sbom-image.json\"\n\necho \"[$(date --utc -Ins)] End sbom-syft-generate\"\n",
+              "environment": {
+                "container": "sbom-syft-generate",
+                "image": "oci://registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": [
+                "--additional-base-images"
+              ],
+              "entryPoint": "#!/bin/bash\nset -euo pipefail\nif [ \"${IMAGE_APPEND_PLATFORM}\" == \"true\" ]; then\n  IMAGE=\"${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}\"\n  export IMAGE\nfi\n\necho \"[$(date --utc -Ins)] Prepare SBOM\"\n\nif [ \"${SKIP_SBOM_GENERATION}\" = \"true\" ]; then\n  echo \"Skipping SBOM generation\"\n  exit 0\nfi\n\n# Convert Tekton array params into Mobster params\nADDITIONAL_BASE_IMAGES=()\nwhile [[ $# -gt 0 ]]; do\n  case $1 in\n  --additional-base-images)\n    shift\n    while [[ $# -gt 0 && $1 != --* ]]; do\n      ADDITIONAL_BASE_IMAGES+=(\"$1\")\n      shift\n    done\n    ;;\n  *)\n    echo \"unexpected argument: $1\" >&2\n    exit 2\n    ;;\n  esac\ndone\n\nIMAGE_URL=\"$(cat \"/tekton/results/IMAGE_URL\")\"\nIMAGE_DIGEST=\"$(cat \"/tekton/results/IMAGE_DIGEST\")\"\n\necho \"[$(date --utc -Ins)] Generate SBOM with mobster\"\n\nmobster_args=(\n  generate\n  --output sbom.json\n  oci-image\n  --from-syft \"/var/workdir/sbom-source.json\"\n  --from-syft \"/var/workdir/sbom-image.json\"\n  --image-pullspec \"$IMAGE_URL\"\n  --image-digest \"$IMAGE_DIGEST\"\n  --parsed-dockerfile-path \"/shared/parsed_dockerfile.json\"\n  --base-image-digest-file \"/shared/base_images_digests\"\n)\n\nif [ -f \"/var/workdir/sbom-prefetch.json\" ]; then\n  mobster_args+=(--from-hermeto \"/var/workdir/sbom-prefetch.json\")\nfi\n\nif [ -n \"${TARGET_STAGE}\" ]; then\n  mobster_args+=(--dockerfile-target \"${TARGET_STAGE}\")\nfi\n\nfor ADDITIONAL_BASE_IMAGE in \"${ADDITIONAL_BASE_IMAGES[@]}\"; do\n  mobster_args+=(--additional-base-image \"$ADDITIONAL_BASE_IMAGE\")\ndone\n\nmobster \"${mobster_args[@]}\"\n\necho \"[$(date --utc -Ins)] End prepare-sboms\"\n",
+              "environment": {
+                "container": "prepare-sboms",
+                "image": "oci://quay.io/konflux-ci/mobster@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -euo pipefail\nif [ \"${IMAGE_APPEND_PLATFORM}\" == \"true\" ]; then\n  IMAGE=\"${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}\"\n  export IMAGE\nfi\n\necho \"[$(date --utc -Ins)] Upload SBOM\"\n\nif [ \"${SKIP_SBOM_GENERATION}\" = \"true\" ]; then\n  echo \"Skipping SBOM generation\"\n  exit 0\nfi\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\n# Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec\nmkdir -p /tmp/auth && select-oci-auth \"$(cat \"/tekton/results/IMAGE_REF\")\" >/tmp/auth/config.json\nexport DOCKER_CONFIG=/tmp/auth\necho \"Pushing sbom to registry\"\nif ! retry cosign attach sbom --sbom sbom.json --type \"$SBOM_TYPE\" \"$(cat \"/tekton/results/IMAGE_REF\")\"; then\n  echo \"Failed to push sbom to registry\"\n  exit 1\nfi\n\n# Remove tag from IMAGE while allowing registry to contain a port number.\nsbom_repo=\"${IMAGE%:*}\"\nsbom_digest=\"$(sha256sum sbom.json | cut -d' ' -f1)\"\n# The SBOM_BLOB_URL is created by `cosign attach sbom`.\necho -n \"${sbom_repo}@sha256:${sbom_digest}\" | tee \"/tekton/results/SBOM_BLOB_URL\"\n\necho\necho \"[$(date --utc -Ins)] End upload-sbom\"\n",
+              "environment": {
+                "container": "upload-sbom",
+                "image": "oci://quay.io/konflux-ci/appstudio-utils@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-images",
+            "clone-repository",
+            "init"
+          ],
+          "finishedOn": "2025-09-24T08:00:48Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "8e5dfb2fac011148f8715bbe0b99415f88297683d269eae0dfcad52562195d45"
+              },
+              "entryPoint": "build-image-index",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-build-image-index"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/60b3a358-d183-43e3-a763-2ed8bb09acd7",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "image-build, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-9e65b81e67c473f2-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "build.appstudio.redhat.com/build_type": "docker",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "build-image-index",
+                "tekton.dev/task": "build-image-index"
+              }
+            },
+            "parameters": {
+              "ALWAYS_BUILD_INDEX": "true",
+              "BUILDAH_FORMAT": "oci",
+              "COMMIT_SHA": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "IMAGE": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "IMAGES": [
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-x86-64@sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-arm64@sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-s390x@sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-ppc64le@sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960"
+              ],
+              "IMAGE_EXPIRES_AFTER": "",
+              "STORAGE_DRIVER": "vfs",
+              "TLSVERIFY": "true"
+            }
+          },
+          "name": "build-image-index",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "build-image-index"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:8e5dfb2fac011148f8715bbe0b99415f88297683d269eae0dfcad52562195d45"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES",
+              "type": "string",
+              "value": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e, quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5, quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c, quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960"
+            },
+            {
+              "name": "IMAGE_DIGEST",
+              "type": "string",
+              "value": "sha256:7fdc006b15c5175fb7b9ac90239cb9e578f0bb132f395dc1411b596388c03db2"
+            },
+            {
+              "name": "IMAGE_REF",
+              "type": "string",
+              "value": "quay.io/araszka/junk:conforma-img@sha256:7fdc006b15c5175fb7b9ac90239cb9e578f0bb132f395dc1411b596388c03db2"
+            },
+            {
+              "name": "IMAGE_URL",
+              "type": "string",
+              "value": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            },
+            {
+              "name": "SBOM_BLOB_URL",
+              "type": "string",
+              "value": "quay.io/araszka/junk:conforma-img@sha256:546621c477df48788ce514f87604902b47c972dddbc0334eb944786133b43ed7"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:32Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-x86-64@sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-arm64@sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-s390x@sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c",
+                "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125-linux-ppc64le@sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960"
+              ],
+              "entryPoint": "#!/bin/bash\n# Fixing group permission on /var/lib/containers\nset -eu\nset -o pipefail\nchown root:root /var/lib/containers\n\nsed -i 's/^\\s*short-name-mode\\s*=\\s*.*/short-name-mode = \"disabled\"/' /etc/containers/registries.conf\n\nif [[ $# -ne 1 && \"$ALWAYS_BUILD_INDEX\" != \"true\" ]]; then\n  echo \"Skipping image index generation while supplying multiple image inputs is unsupported.\"\n  exit 2\nfi\n\nbuildah manifest create \"$IMAGE\"\nfor i in $@\ndo\n  TOADD=\"$i\"\n  TOADD_URL=\"$(echo \"$i\" | cut -d@ -f1)\"\n  TOADD_DIGEST=\"$(echo \"$i\" | cut -d@ -f2)\"\n  if [[ $(echo \"$i\" | tr -cd \":\" | wc -c) == 2 ]]; then\n    #format is repository:tag@sha256:digest\n    #we need to remove the tag, and just reference the digest\n    #as tag + digest is not supported\n    TOADD_REPOSITORY=\"$(echo \"$i\" | cut -d: -f1)\"\n    TOADD=\"${TOADD_REPOSITORY}@${TOADD_DIGEST}\"\n  fi\n  if [[ \"$ALWAYS_BUILD_INDEX\" != \"true\" ]]; then\n    echo \"Skipping image index generation. Returning results for $TOADD.\"\n    echo -n \"${TOADD_URL}\" > \"/tekton/results/IMAGE_URL\"\n    echo -n \"${TOADD_DIGEST}\" > \"/tekton/results/IMAGE_DIGEST\"\n    echo -n \"${TOADD}\" > \"/tekton/results/IMAGES\"\n    exit 0\n  fi\n  echo \"Adding $TOADD\"\n  buildah manifest add $IMAGE \"docker://$TOADD\" --all\ndone\n\n# While the BUILDAH_FORMAT environment variable can define the push\n# format, lets be explicit about the format that we want when we push.\npush_format=oci\nif [ \"${BUILDAH_FORMAT}\" == \"docker\" ]; then\n  push_format=docker\nfi\n\nbuildah_retries=3\n\necho \"Pushing image to registry\"\nif ! retry buildah manifest push \\\n  --format=\"$push_format\" \\\n  --retry \"$buildah_retries\" \\\n  --tls-verify=\"$TLSVERIFY\" \\\n  --digestfile image-digest \\\n  \"$IMAGE\" \\\n  \"docker://$IMAGE\"\nthen\n    echo \"Failed to push image ${IMAGE} to registry\"\n    exit 1\nfi\n\necho \"Pushing image to registry\"\nif ! retry buildah manifest push \\\n  --format=\"$push_format\" \\\n  --retry \"$buildah_retries\" \\\n  --tls-verify=\"$TLSVERIFY\" \\\n  --digestfile image-digest \\\n  \"$IMAGE\" \\\n  \"docker://${IMAGE%:*}:ubi10-10-0-on-push-t2x6l-build-image-index\"\nthen\n    echo \"Failed to push image ${IMAGE%:*}:ubi10-10-0-on-push-t2x6l-build-image-index to registry\"\n    exit 1\nfi\n\nINDEX_REPOSITORY=\"$(echo \"$IMAGE\" | cut -d@ -f1 | cut -d: -f1)\"\nMANIFEST_DIGESTS=$(buildah manifest inspect \"$IMAGE\" | jq -er \".manifests[].digest\")\nimage_manifests=\"\"\nfor i in $MANIFEST_DIGESTS\ndo\n  image_manifests=\"${image_manifests} ${INDEX_REPOSITORY}@${i},\"\ndone\n\ncat image-digest | tee /tekton/results/IMAGE_DIGEST\necho -n \"$IMAGE\" | tee \"/tekton/results/IMAGE_URL\"\n{\n  echo -n \"${IMAGE}@\"\n  cat \"image-digest\"\n} > \"/tekton/results/IMAGE_REF\"\necho -n \"${image_manifests:1:-1}\" > \"/tekton/results/IMAGES\"\n\n# buildah manifest inspect will always give precedence to the local image.\n# Since we built this image in the same place as we are inspecting it, we can\n# just inspect it instead of finding the digest and inspecting the remote image.\nbuildah manifest inspect \"$IMAGE\" > /index-build-data/manifest_data.json\n",
+              "environment": {
+                "container": "build",
+                "image": "oci://quay.io/konflux-ci/buildah-task@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -e\n\nMANIFEST_DATA_FILE=\"/index-build-data/manifest_data.json\"\nif [ ! -f \"$MANIFEST_DATA_FILE\" ]; then\n  echo \"The manifest_data.json file does not exist. Skipping the SBOM creation...\"\n  exit 0\nfi\n\nIMAGE_URL=\"$(cat \"/tekton/results/IMAGE_URL\")\"\nIMAGE_DIGEST=\"$(cat \"/tekton/results/IMAGE_DIGEST\")\"\necho \"Creating SBOM result file...\"\nmobster generate \\\n  --output /index-build-data/index.spdx.json \\\n  oci-index \\\n  --index-image-pullspec \"$IMAGE_URL\" \\\n  --index-image-digest \"$IMAGE_DIGEST\" \\\n  --index-manifest-path \"$MANIFEST_DATA_FILE\" \\\n",
+              "environment": {
+                "container": "create-sbom",
+                "image": "oci://quay.io/konflux-ci/mobster@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -e\n\nSBOM_RESULT_FILE=\"/index-build-data/index.spdx.json\"\nif [ ! -f \"$SBOM_RESULT_FILE\" ]; then\n  echo \"The index.spdx.json file does not exists. Skipping the SBOM upload...\"\n  exit 0\nfi\n\n# Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec\nmkdir -p /tmp/auth && select-oci-auth \"$(cat \"/tekton/results/IMAGE_REF\")\" > /tmp/auth/config.json\nexport DOCKER_CONFIG=/tmp/auth\n\necho \"Pushing sbom to registry\"\nif ! retry cosign attach sbom --sbom \"$SBOM_RESULT_FILE\" --type spdx \"$(cat \"/tekton/results/IMAGE_REF\")\"\nthen\n    echo \"Failed to push sbom to registry\"\n    exit 1\nfi\n\n# Remove tag from IMAGE while allowing registry to contain a port number.\nsbom_repo=\"${IMAGE%:*}\"\nsbom_digest=\"$(sha256sum \"$SBOM_RESULT_FILE\" | cut -d' ' -f1)\"\n# The SBOM_BLOB_URL is created by `cosign attach sbom`.\necho -n \"${sbom_repo}@sha256:${sbom_digest}\" | tee \"/tekton/results/SBOM_BLOB_URL\"\n",
+              "environment": {
+                "container": "upload-sbom",
+                "image": "oci://quay.io/konflux-ci/appstudio-utils@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index",
+            "prefetch-dependencies",
+            "init"
+          ],
+          "finishedOn": "2025-09-24T08:09:42Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "b0d6cb28a23f20db4f5cf78ed78ae3a91b9a5adfe989696ed0bbc63840a485b6"
+              },
+              "entryPoint": "source-build-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-57f3eab16eb391bb-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "build-source-image",
+                "tekton.dev/task": "source-build-oci-ta"
+              }
+            },
+            "parameters": {
+              "BASE_IMAGES": "",
+              "BINARY_IMAGE": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "BINARY_IMAGE_DIGEST": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "CACHI2_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007",
+              "IGNORE_UNSIGNED_IMAGE": "false",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7",
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca"
+            }
+          },
+          "name": "build-source-image",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "source-build-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:b0d6cb28a23f20db4f5cf78ed78ae3a91b9a5adfe989696ed0bbc63840a485b6"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "BUILD_RESULT",
+              "type": "string",
+              "value": "{\"status\": \"success\", \"dependencies_included\": true, \"base_image_source_included\": false, \"image_url\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:sha256-e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740.src\", \"image_digest\": \"sha256:4a916dbebd3c55fd6298095d39496388f35e69bb52e7623c4f2d1e7f61388c35\"}"
+            },
+            {
+              "name": "IMAGE_REF",
+              "type": "string",
+              "value": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:sha256-e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740.src@sha256:4a916dbebd3c55fd6298095d39496388f35e69bb52e7623c4f2d1e7f61388c35"
+            },
+            {
+              "name": "SOURCE_IMAGE_DIGEST",
+              "type": "string",
+              "value": "sha256:4a916dbebd3c55fd6298095d39496388f35e69bb52e7623c4f2d1e7f61388c35"
+            },
+            {
+              "name": "SOURCE_IMAGE_URL",
+              "type": "string",
+              "value": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:sha256-e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740.src"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:50Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7=/var/workdir/source",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007=/var/workdir/cachi2"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:1abf94de338e54dd17a0fb84b6d042d1790ede6d1adf235995db5dc1011886f8"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n\nif [[ ! $BINARY_IMAGE_DIGEST =~ ^sha256:[[:xdigit:]]+$ ]]; then\n  echo \"$BINARY_IMAGE_DIGEST is not a valid sha256 digest.\"\n  exit 1\nfi\n\nif [[ -n \"$BASE_IMAGES\" ]]; then\n  echo \"BASE_IMAGES param received:\"\n  printf \"%s\" \"$BASE_IMAGES\" | tee \"$BASE_IMAGES_FILE\"\n  exit\nfi\n\necho \"BASE_IMAGES param is empty, inspecting the SBOM instead\"\n\nimage_pinned_by_digest=\"${BINARY_IMAGE%:*}@${BINARY_IMAGE_DIGEST}\"\n\nif raw_inspect=$(skopeo inspect --raw \"docker://${image_pinned_by_digest}\"); then\n  echo \"Got manifest of image ${image_pinned_by_digest}\"\nelse\n  if [[ $? == 2 ]]; then\n    printf \"Binary image %s no longer exists in the registry.\\n\" \"$image_pinned_by_digest\" |\n      tee \"$IMAGE_NOT_EXIST_FLAG\"\n    exit\n  else\n    exit 1\n  fi\nfi\n\nif manifest_digest=$(jq -e -r '.manifests[0].digest' <<<\"$raw_inspect\"); then\n  # The BINARY_IMAGE is an image index, each manifest in the list has its own SBOM.\n  # We're gonna assume the base images are the same or similar enough in all the SBOMs.\n  echo \"Image (${image_pinned_by_digest}) is a manifest list, picking an arbitrary image from the list\"\n  image=${image_pinned_by_digest%@*}@${manifest_digest}\nelse\n  # The image is a single manifest\n  image=$image_pinned_by_digest\nfi\n\n# Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec\nmkdir -p /tmp/auth && select-oci-auth \"$image\" >/tmp/auth/config.json\n\nfor i in {1..5}; do\n  echo \"Downloading SBOM for $image (attempt $i)\"\n  sbom=$(DOCKER_CONFIG=/tmp/auth cosign download sbom \"$image\") && break\n  [[ \"$i\" -lt 5 ]] && sleep 1\ndone\n\nif [[ -z \"$sbom\" ]]; then\n  echo \"Failed to download SBOM after 5 attempts. Proceeding anyway.\"\n  echo \"WARNING: the source image will not include sources for the base image.\"\n  exit 0\nfi\n\necho -n \"Looking for base image in SBOM\"\n\n# Note: the SBOM should contain at most one image with the is_base_image property - the\n# base image for the last FROM instruction. That is the only base image we care about.\nif jq -e '.bomFormat == \"CycloneDX\"' <<<\"$sbom\" >/dev/null; then\n  echo \" (.formulation[].components[] with 'konflux:container:is_base_image' property)\"\n  jq -r '\n        .formulation[]?\n        | .components[]?\n        | select(any(.properties[]?; .name == \"konflux:container:is_base_image\"))\n        | (\n            .purl\n            | capture(\"^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\\\?[^#]*repository_url=(?<repository_url>[^&#]*))?\")\n          ) as $matched\n        | $matched.repository_url + \"@\" + $matched.digest\n    ' <<<\"$sbom\" | tee \"$BASE_IMAGES_FILE\"\nelse\n  echo ' (a package with a {\"name\": \"konflux:container:is_base_image\"} JSON-encoded annotation)'\n  jq -r '\n          .packages[]\n          | select(any(.annotations[]?.comment; (fromjson?).name? == \"konflux:container:is_base_image\"))\n          | [.externalRefs[]? | select(.referenceType == \"purl\").referenceLocator] as $purls\n          | (\n              $purls | first\n              | capture(\"^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\\\?[^#]*repository_url=(?<repository_url>[^&#]*))?\")\n            ) as $matched\n          | $matched.repository_url + \"@\" + $matched.digest\n\n    ' <<<\"$sbom\" | tee \"$BASE_IMAGES_FILE\"\nfi\n",
+              "environment": {
+                "container": "get-base-images",
+                "image": "oci://quay.io/konflux-ci/appstudio-utils@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n\nif [ -f \"$IMAGE_NOT_EXIST_FLAG\" ]; then\n  echo \"Drop building source container image.\"\n  printf \"\" >\"$RESULT_SOURCE_IMAGE_URL\"\n  printf \"\" >\"$RESULT_SOURCE_IMAGE_DIGEST\"\n  printf \"\" >\"$RESULT_IMAGE_REF\"\n  message=$(cat \"$IMAGE_NOT_EXIST_FLAG\")\n  printf \"{\\\"status\\\": \\\"drop\\\", \\\"message\\\": \\\"%s\\\"}\" \"$message\" >\"$WS_BUILD_RESULT_FILE\"\n  exit\nfi\n\napp_dir=/opt/source_build\nregistry_allowlist=\"\nregistry.access.redhat.com\nregistry.redhat.io\n\"\n\n## This is needed for the builds performed by the rpm-ostree task\n## otherwise, we can see this error:\n## \"fatal: detected dubious ownership in repository at '/var/workdir/source'\"\n##\ngit config --global --add safe.directory $SOURCE_DIR\n\nbase_images=$(if [[ -f \"$BASE_IMAGES_FILE\" ]]; then cat \"$BASE_IMAGES_FILE\"; fi)\n\nargs=(\n  --binary-image-ref \"${BINARY_IMAGE}@${BINARY_IMAGE_DIGEST}\"\n  --workspace /var/workdir\n  --source-dir \"$SOURCE_DIR\"\n  --base-images \"$base_images\"\n  --write-result-to \"$RESULT_FILE\"\n  --prefetch-artifacts-dir \"$CACHI2_ARTIFACTS_DIR\"\n  --registry-allowlist=\"$registry_allowlist\"\n)\nif [ \"$IGNORE_UNSIGNED_IMAGE\" == \"true\" ]; then\n  args+=(--ignore-unsigned-image)\nfi\n\n${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \"${args[@]}\"\n\ncat \"$RESULT_FILE\" | jq -j \".image_url\" >\"$RESULT_SOURCE_IMAGE_URL\"\ncat \"$RESULT_FILE\" | jq -j \".image_digest\" >\"$RESULT_SOURCE_IMAGE_DIGEST\"\njq -j '\"\\(.image_url)@\\(.image_digest)\"' \"${RESULT_FILE}\" >\"$RESULT_IMAGE_REF\"\n\ncp \"$RESULT_FILE\" \"$WS_BUILD_RESULT_FILE\"\n",
+              "environment": {
+                "container": "build",
+                "image": "oci://quay.io/konflux-ci/source-container-build@sha256:db0a53425f0e43c32450deab48380eb1350c47424c3e4ae61555547f009604ef"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:00:58Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "2c32152a55f6bfba67b41be456da46b6e109bb3e348e25220eed4eed149958c5"
+              },
+              "entryPoint": "deprecated-image-check",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/d6c94ea8-ebef-4afd-a00b-08184fe00ac2",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-64c64ba0f4167495-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "deprecated-base-image-check",
+                "tekton.dev/task": "deprecated-image-check"
+              }
+            },
+            "parameters": {
+              "BASE_IMAGES_DIGESTS": "",
+              "CA_TRUST_CONFIG_MAP_KEY": "ca-bundle.crt",
+              "CA_TRUST_CONFIG_MAP_NAME": "trusted-ca",
+              "IMAGE_DIGEST": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "IMAGE_URL": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "POLICY_DIR": "/project/repository/",
+              "POLICY_NAMESPACE": "required_checks"
+            }
+          },
+          "name": "deprecated-base-image-check",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "deprecated-image-check"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:2c32152a55f6bfba67b41be456da46b6e109bb3e348e25220eed4eed149958c5"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e\",\"sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5\",\"sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c\",\"sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:00:58+00:00\",\"note\":\"Task deprecated-image-check completed: Check result for task result.\",\"namespace\":\"required_checks\",\"successes\":1,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nIMAGES_TO_BE_PROCESSED_PATH=\"/tmp/images_to_be_processed.txt\"\ntouch /tmp/images_to_be_processed.txt\n\nsuccess_counter=0\nfailure_counter=0\nerror_counter=0\nwarnings_counter=0\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo -n $imagewithouttag@$IMAGE_DIGEST)\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    SBOM_FILE_PATH=$(echo \"/tmp/sbom-$arch.json\")\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n\n    # Get base images from SBOM\n    cosign download sbom $arch_imageanddigest > ${SBOM_FILE_PATH}\n    if [ $? -ne 0 ]; then\n      echo \"Unable to download sbom for arch $arch.\"\n      continue\n    fi\n\n    < \"${SBOM_FILE_PATH}\" jq -r '\n        if .bomFormat == \"CycloneDX\" then\n            .formulation[]?\n            | .components[]?\n            | select(any(.properties[]?; .name | test(\"^konflux:container:is_(base|builder)_image\")))\n            | (\n                .purl\n                | capture(\"^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\\\?[^#]*repository_url=(?<repository_url>[^&#]*))?\")\n              ) as $matched\n            | $matched.repository_url\n        else\n            .packages[]\n            | select(any(.annotations[]?.comment; (fromjson?).name? | test(\"^konflux:container:is_(base|builder)_image\")?))\n            | [.externalRefs[]? | select(.referenceType == \"purl\").referenceLocator] as $purls\n            | (\n                $purls | first\n                | capture(\"^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\\\?[^#]*repository_url=(?<repository_url>[^&#]*))?\")\n              ) as $matched\n            | $matched.repository_url\n        end\n    ' >> \"${IMAGES_TO_BE_PROCESSED_PATH}\"\n    echo \"Detected base images from $arch SBOM:\"\n    cat \"${IMAGES_TO_BE_PROCESSED_PATH}\"\n    echo \"\"\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task deprecated-image-check failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\n\nif [ -n \"${BASE_IMAGES_DIGESTS}\" ];\nthen\n  echo \"Base images passed by param BASE_IMAGES_DIGESTS: $BASE_IMAGES_DIGESTS\"\n  # Get images from the parameter\n  for IMAGE_WITH_TAG in $(echo -n \"$BASE_IMAGES_DIGESTS\" | sed 's/\\\\n/\\'$'\\n''/g' );\n  do\n    echo $IMAGE_WITH_TAG | cut -d \":\" -f1 >> ${IMAGES_TO_BE_PROCESSED_PATH}\n  done\nfi\n\n# we want to remove duplicated entries\nBASE_IMAGES=$(sort -u \"${IMAGES_TO_BE_PROCESSED_PATH}\")\n\necho \"Images to be checked:\"\necho \"$BASE_IMAGES\"\necho \"\"\n\nfor BASE_IMAGE in ${BASE_IMAGES};\ndo\n  IFS=:'/' read -r IMAGE_REGISTRY IMAGE_REPOSITORY<<< $BASE_IMAGE\n\n  # Red Hat Catalog hack: registry.redhat.io must be queried as registry.access.redhat.com in Red Hat catalog\n  IMAGE_REGISTRY_CATALOG=$(echo \"${IMAGE_REGISTRY}\" | sed 's/^registry.redhat.io$/registry.access.redhat.com/')\n\n  export IMAGE_REPO_PATH=/tmp/${IMAGE_REPOSITORY}\n  mkdir -p ${IMAGE_REPO_PATH}\n  echo \"Querying Red Hat Catalog for $BASE_IMAGE.\"\n  http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' \"https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY_CATALOG}/repository/${IMAGE_REPOSITORY}\")\n\n  if [ \"$http_code\" == \"200\" ];\n  then\n    echo \"Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace.\"\n    /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \\\n    --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \\\n    --output=json | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json\n\n    failures_num=$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)\n    if [[ \"${failures_num}\" -gt 0 ]]; then\n      echo \"[FAILURE] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} has been deprecated\"\n    fi\n    failure_counter=$((failure_counter+failures_num))\n\n    successes_num=$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)\n    if [[ \"${successes_num}\" -gt 0 ]]; then\n      echo \"[SUCCESS] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} is valid\"\n    fi\n    success_counter=$((success_counter+successes_num))\n\n  elif [ \"$http_code\" == \"404\" ];\n  then\n    echo \"[WARNING] Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Red Hat Catalog. Task cannot provide results if image is deprecated.\"\n    warnings_counter=$((warnings_counter+1))\n  else\n    echo \"[ERROR] Unexpected error (HTTP code: ${http_code}) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}.\"\n    error_counter=$((error_counter+1))\n  fi\ndone\n\nnote=\"Task deprecated-image-check failed: Command conftest failed. For details, check Tekton task log.\"\nERROR_OUTPUT=$(make_result_json -r ERROR -n \"$POLICY_NAMESPACE\" -t \"$note\")\n\nnote=\"Task deprecated-image-check completed: Check result for task result.\"\nif [[ \"$error_counter\" == 0 ]];\nthen\n  if [[ \"${failure_counter}\" -gt 0 ]]; then\n    RES=\"FAILURE\"\n  elif [[ \"${warnings_counter}\" -gt 0 ]]; then\n    RES=\"WARNING\"\n  elif [[ \"${success_counter}\" -eq 0 ]]; then\n    # when all counters are 0, there are no base images to check\n    note=\"Task deprecated-image-check success: No base images to check.\"\n    RES=\"SUCCESS\"\n  else\n    RES=\"SUCCESS\"\n  fi\n  TEST_OUTPUT=$(make_result_json \\\n    -r \"${RES}\" -n \"$POLICY_NAMESPACE\" \\\n    -s \"${success_counter}\" -f \"${failure_counter}\" -w \"${warnings_counter}\" -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee /tekton/results/TEST_OUTPUT\n\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
+              "environment": {
+                "container": "check-images",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:42ffa0248c10ffa4ba1d5e606d1ad4265dc4fd52c4988ce63be4929d31df7504"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:11Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              "entryPoint": "clair-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clair-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/48a40a88-a828-44e3-83f6-8e9ce4e67ef6",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-bf8cf9c004ad854a-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clair-scan",
+                "tekton.dev/task": "clair-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "docker-auth": "",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-platform": "linux/arm64",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clair-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clair-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "REPORTS",
+              "type": "string",
+              "value": "{\"sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5\":\"sha256:5c56d5e180c3cb9779c1a9016e8c34b073b08384b4051d12d574556ba64eac5c\"}\n"
+            },
+            {
+              "name": "SCAN_OUTPUT",
+              "type": "string",
+              "value": "{\"vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":0,\"unknown\":0},\"unpatched_vulnerabilities\":{\"critical\":0,\"high\":5,\"medium\":24,\"low\":37,\"unknown\":0}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:01:10+00:00\",\"note\":\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n# shellcheck source=/dev/null\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\necho \"Inspecting raw image manifest $imageanddigest.\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\nif [ -n \"$image_manifests\" ]; then\n  echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"' | while read -r arch arch_sha; do\n    echo \"$arch_sha\" > /tekton/home/image-manifest-$arch.sha\n  done\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clair-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n",
+              "environment": {
+                "container": "get-image-manifests",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n# shellcheck source=/utils.sh\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\n\n# the quay report format used by the Conftest rules in the\n# conftest-vulnerabilities step doesn't contain the \"issued\" date which\n# we require in the policy rules, so we resort to running clair-action\n# twice to produce both quay and clair formatted output\nclair_report() {\n  { retry clair-action report --image-ref=\"$1\" --db-path=/tmp/matcher.db --format=clair | tee  \"clair-report-$2.json\"; } && \\\n  { retry clair-action convert  --file-path=\"clair-report-$2.json\" --format=quay > \"clair-result-$2.json\"; }\n}\n\nrun_clair_on_arch() {\n  local arch=\"$1\"\n  local sha_file=\"image-manifest-$arch.sha\"\n\n  if [ -e \"$sha_file\" ]; then\n    local arch_sha\n    arch_sha=$(<\"$sha_file\")\n    local digest=\"${imagewithouttag}@${arch_sha}\"\n\n    echo \"Running clair-action on $arch image manifest...\"\n    clair_report \"$digest\" \"$arch\" || true\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n   fi\n}\n\nplatform=\"${IMAGE_PLATFORM}\"\n\n# If a platform is specified, extract the architecture and run clair-action on the corresponding image manifest\nif [ -n \"$platform\" ]; then\n  arch=\"${platform#*/}\"\n  if [ \"$arch\" = \"x86_64\" ] || [ \"$arch\" = \"local\" ] || [ \"$arch\" = \"localhost\" ]; then\n    arch=\"amd64\"\n  fi\n  # Validate against supported arch list. If it's not a known arch, fallback to amd64\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      echo \"Error: Unsupported or malformed architecture: '$arch' (parsed from platform: '$platform')\"\n      exit 0\n      ;;\n  esac\n\n  run_clair_on_arch \"$arch\"\n\n# If no platform is specified, run clair-action on all available image manifests\nelse\n  for sha_file in image-manifest-*.sha; do\n    if [ -e \"$sha_file\" ]; then\n      arch=$(basename \"$sha_file\" | sed 's/image-manifest-//;s/.sha//')\n      run_clair_on_arch \"$arch\"\n    fi\n  done\nfi\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\n\nimages_processed=$(echo \"${images_processed_template/\\[%s]/[$digests_processed_string]}\")\necho \"$images_processed\" > images-processed.json\n",
+              "environment": {
+                "container": "get-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/clair-in-ci@sha256:6386cbb69b5ddf94168f9397a8795365f4d7500103e15ec8f6bd256afd75a33b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nif ! compgen -G \"clair-report-*.json\" > /dev/null; then\n  echo 'No Clair reports generated. Skipping upload.'\n  exit 0\nfi\n\necho \"Selecting auth\"\nselect-oci-auth \"$IMAGE_URL\" > \"$HOME/auth.json\"\n\nrepository=\"${IMAGE_URL/:*/}\"\n\narch() {\n  report_file=\"$1\"\n  arch=\"${report_file/*-}\"\n  echo \"${arch/.json/}\"\n}\n\nMEDIA_TYPE='application/vnd.redhat.clair-report+json'\n\nreports_json=\"\"\nfor f in clair-report-*.json; do\n  digest=$(cat \"image-manifest-$(arch \"$f\").sha\")\n  image_ref=\"${repository}@${digest}\"\n  echo \"Attaching $f to ${image_ref}\"\n  if ! report_digest=\"$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \\\n    \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${image_ref}\" \"$f:${MEDIA_TYPE}\")\"\n  then\n    echo \"Failed to attach ${f} to ${image_ref}\"\n    exit 1\n  fi\n  # shellcheck disable=SC2016\n  reports_json=\"$(yq --output-format json --indent=0 eval-all '. as $i ireduce ({}; . * $i)' <(echo \"${reports_json}\") <(echo \"${digest}: ${report_digest}\"))\"\ndone\necho \"${reports_json}\" > reports.json\n",
+              "environment": {
+                "container": "oci-attach-report",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nclair_result_files=$(ls /tekton/home/clair-result-*.json)\nif [ -z \"$clair_result_files\" ]; then\n  echo \"Previous step [get-vulnerabilities] failed: No clair-result files found in /tekton/home.\"\nfi\n\nmissing_vulnerabilities_files=\"\"\nfor file in $clair_result_files; do\n  file_suffix=$(basename \"$file\" | sed 's/clair-result-//;s/.json//')\n  if [ ! -s \"$file\" ]; then\n    echo \"Previous step [get-vulnerabilities] failed: $file is empty.\"\n  else\n    /usr/bin/conftest test --no-fail $file \\\n    --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \\\n    --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true\n  fi\n\n  #check for missing \"clair-vulnerabilities-<arch>/image-index\" file and create a string\n  if [ ! -f \"/tekton/home/clair-vulnerabilities-$file_suffix.json\" ]; then\n    missing_vulnerabilities_files+=\"${missing_vulnerabilities_files:+, }/tekton/home/clair-vulnerabilities-$file_suffix.json\"\n  fi\ndone\n\nif [ -n \"$missing_vulnerabilities_files\" ]; then\n  note=\"Task clair-scan failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log.\"\n  TEST_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log.\"\n  echo \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\nscan_result='{\"vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}, \"unpatched_vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}}'\nfor file in /tekton/home/clair-vulnerabilities-*.json; do\n    result=$(jq -rce \\\n        '{\n            vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            },\n            unpatched_vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            }\n        }' \"$file\")\n\n    scan_result=$(jq -s -rce \\\n          '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |\n          .[0].vulnerabilities.high += .[1].vulnerabilities.high |\n          .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |\n          .[0].vulnerabilities.low += .[1].vulnerabilities.low |\n          .[0].vulnerabilities.unknown += .[1].vulnerabilities.unknown |\n          .[0].unpatched_vulnerabilities.critical += .[1].unpatched_vulnerabilities.critical |\n          .[0].unpatched_vulnerabilities.high += .[1].unpatched_vulnerabilities.high |\n          .[0].unpatched_vulnerabilities.medium += .[1].unpatched_vulnerabilities.medium |\n          .[0].unpatched_vulnerabilities.low += .[1].unpatched_vulnerabilities.low |\n          .[0].unpatched_vulnerabilities.unknown += .[1].unpatched_vulnerabilities.unknown |\n          .[0]' <<<\"$scan_result $result\")\ndone\n\necho \"$scan_result\" | tee \"/tekton/results/SCAN_OUTPUT\"\n\ncat /tekton/home/images-processed.json | tee /tekton/results/IMAGES_PROCESSED\n# shellcheck disable=SC2154\ncat /tekton/home/reports.json > \"/tekton/results/REPORTS\"\n\nnote=\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\"\nTEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n",
+              "environment": {
+                "container": "conftest-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:10Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              "entryPoint": "clair-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clair-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/25c68d2c-83ab-4770-8821-109ea1e7ab38",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-3feb30b999ba16a5-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clair-scan",
+                "tekton.dev/task": "clair-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "docker-auth": "",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-platform": "linux/ppc64le",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clair-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clair-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "REPORTS",
+              "type": "string",
+              "value": "{\"sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960\":\"sha256:dc0d76be27464e4b4ac852bf5f19237944222608abebc7f0f4121fd7a3446810\"}\n"
+            },
+            {
+              "name": "SCAN_OUTPUT",
+              "type": "string",
+              "value": "{\"vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":0,\"unknown\":0},\"unpatched_vulnerabilities\":{\"critical\":0,\"high\":5,\"medium\":24,\"low\":37,\"unknown\":0}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:01:09+00:00\",\"note\":\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n# shellcheck source=/dev/null\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\necho \"Inspecting raw image manifest $imageanddigest.\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\nif [ -n \"$image_manifests\" ]; then\n  echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"' | while read -r arch arch_sha; do\n    echo \"$arch_sha\" > /tekton/home/image-manifest-$arch.sha\n  done\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clair-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n",
+              "environment": {
+                "container": "get-image-manifests",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n# shellcheck source=/utils.sh\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\n\n# the quay report format used by the Conftest rules in the\n# conftest-vulnerabilities step doesn't contain the \"issued\" date which\n# we require in the policy rules, so we resort to running clair-action\n# twice to produce both quay and clair formatted output\nclair_report() {\n  { retry clair-action report --image-ref=\"$1\" --db-path=/tmp/matcher.db --format=clair | tee  \"clair-report-$2.json\"; } && \\\n  { retry clair-action convert  --file-path=\"clair-report-$2.json\" --format=quay > \"clair-result-$2.json\"; }\n}\n\nrun_clair_on_arch() {\n  local arch=\"$1\"\n  local sha_file=\"image-manifest-$arch.sha\"\n\n  if [ -e \"$sha_file\" ]; then\n    local arch_sha\n    arch_sha=$(<\"$sha_file\")\n    local digest=\"${imagewithouttag}@${arch_sha}\"\n\n    echo \"Running clair-action on $arch image manifest...\"\n    clair_report \"$digest\" \"$arch\" || true\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n   fi\n}\n\nplatform=\"${IMAGE_PLATFORM}\"\n\n# If a platform is specified, extract the architecture and run clair-action on the corresponding image manifest\nif [ -n \"$platform\" ]; then\n  arch=\"${platform#*/}\"\n  if [ \"$arch\" = \"x86_64\" ] || [ \"$arch\" = \"local\" ] || [ \"$arch\" = \"localhost\" ]; then\n    arch=\"amd64\"\n  fi\n  # Validate against supported arch list. If it's not a known arch, fallback to amd64\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      echo \"Error: Unsupported or malformed architecture: '$arch' (parsed from platform: '$platform')\"\n      exit 0\n      ;;\n  esac\n\n  run_clair_on_arch \"$arch\"\n\n# If no platform is specified, run clair-action on all available image manifests\nelse\n  for sha_file in image-manifest-*.sha; do\n    if [ -e \"$sha_file\" ]; then\n      arch=$(basename \"$sha_file\" | sed 's/image-manifest-//;s/.sha//')\n      run_clair_on_arch \"$arch\"\n    fi\n  done\nfi\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\n\nimages_processed=$(echo \"${images_processed_template/\\[%s]/[$digests_processed_string]}\")\necho \"$images_processed\" > images-processed.json\n",
+              "environment": {
+                "container": "get-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/clair-in-ci@sha256:6386cbb69b5ddf94168f9397a8795365f4d7500103e15ec8f6bd256afd75a33b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nif ! compgen -G \"clair-report-*.json\" > /dev/null; then\n  echo 'No Clair reports generated. Skipping upload.'\n  exit 0\nfi\n\necho \"Selecting auth\"\nselect-oci-auth \"$IMAGE_URL\" > \"$HOME/auth.json\"\n\nrepository=\"${IMAGE_URL/:*/}\"\n\narch() {\n  report_file=\"$1\"\n  arch=\"${report_file/*-}\"\n  echo \"${arch/.json/}\"\n}\n\nMEDIA_TYPE='application/vnd.redhat.clair-report+json'\n\nreports_json=\"\"\nfor f in clair-report-*.json; do\n  digest=$(cat \"image-manifest-$(arch \"$f\").sha\")\n  image_ref=\"${repository}@${digest}\"\n  echo \"Attaching $f to ${image_ref}\"\n  if ! report_digest=\"$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \\\n    \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${image_ref}\" \"$f:${MEDIA_TYPE}\")\"\n  then\n    echo \"Failed to attach ${f} to ${image_ref}\"\n    exit 1\n  fi\n  # shellcheck disable=SC2016\n  reports_json=\"$(yq --output-format json --indent=0 eval-all '. as $i ireduce ({}; . * $i)' <(echo \"${reports_json}\") <(echo \"${digest}: ${report_digest}\"))\"\ndone\necho \"${reports_json}\" > reports.json\n",
+              "environment": {
+                "container": "oci-attach-report",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nclair_result_files=$(ls /tekton/home/clair-result-*.json)\nif [ -z \"$clair_result_files\" ]; then\n  echo \"Previous step [get-vulnerabilities] failed: No clair-result files found in /tekton/home.\"\nfi\n\nmissing_vulnerabilities_files=\"\"\nfor file in $clair_result_files; do\n  file_suffix=$(basename \"$file\" | sed 's/clair-result-//;s/.json//')\n  if [ ! -s \"$file\" ]; then\n    echo \"Previous step [get-vulnerabilities] failed: $file is empty.\"\n  else\n    /usr/bin/conftest test --no-fail $file \\\n    --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \\\n    --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true\n  fi\n\n  #check for missing \"clair-vulnerabilities-<arch>/image-index\" file and create a string\n  if [ ! -f \"/tekton/home/clair-vulnerabilities-$file_suffix.json\" ]; then\n    missing_vulnerabilities_files+=\"${missing_vulnerabilities_files:+, }/tekton/home/clair-vulnerabilities-$file_suffix.json\"\n  fi\ndone\n\nif [ -n \"$missing_vulnerabilities_files\" ]; then\n  note=\"Task clair-scan failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log.\"\n  TEST_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log.\"\n  echo \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\nscan_result='{\"vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}, \"unpatched_vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}}'\nfor file in /tekton/home/clair-vulnerabilities-*.json; do\n    result=$(jq -rce \\\n        '{\n            vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            },\n            unpatched_vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            }\n        }' \"$file\")\n\n    scan_result=$(jq -s -rce \\\n          '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |\n          .[0].vulnerabilities.high += .[1].vulnerabilities.high |\n          .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |\n          .[0].vulnerabilities.low += .[1].vulnerabilities.low |\n          .[0].vulnerabilities.unknown += .[1].vulnerabilities.unknown |\n          .[0].unpatched_vulnerabilities.critical += .[1].unpatched_vulnerabilities.critical |\n          .[0].unpatched_vulnerabilities.high += .[1].unpatched_vulnerabilities.high |\n          .[0].unpatched_vulnerabilities.medium += .[1].unpatched_vulnerabilities.medium |\n          .[0].unpatched_vulnerabilities.low += .[1].unpatched_vulnerabilities.low |\n          .[0].unpatched_vulnerabilities.unknown += .[1].unpatched_vulnerabilities.unknown |\n          .[0]' <<<\"$scan_result $result\")\ndone\n\necho \"$scan_result\" | tee \"/tekton/results/SCAN_OUTPUT\"\n\ncat /tekton/home/images-processed.json | tee /tekton/results/IMAGES_PROCESSED\n# shellcheck disable=SC2154\ncat /tekton/home/reports.json > \"/tekton/results/REPORTS\"\n\nnote=\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\"\nTEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n",
+              "environment": {
+                "container": "conftest-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:13Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              "entryPoint": "clair-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clair-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/28c5310e-c459-492b-9ee4-cfaef6f434fc",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-f6f4b25884c49d99-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clair-scan",
+                "tekton.dev/task": "clair-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "docker-auth": "",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-platform": "linux/x86_64",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clair-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clair-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "REPORTS",
+              "type": "string",
+              "value": "{\"sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e\":\"sha256:00c95828256e678c60ba629f795e4284e82c830b675af377ad369cecd9221a1e\"}\n"
+            },
+            {
+              "name": "SCAN_OUTPUT",
+              "type": "string",
+              "value": "{\"vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":0,\"unknown\":0},\"unpatched_vulnerabilities\":{\"critical\":0,\"high\":5,\"medium\":24,\"low\":37,\"unknown\":0}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:01:12+00:00\",\"note\":\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n# shellcheck source=/dev/null\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\necho \"Inspecting raw image manifest $imageanddigest.\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\nif [ -n \"$image_manifests\" ]; then\n  echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"' | while read -r arch arch_sha; do\n    echo \"$arch_sha\" > /tekton/home/image-manifest-$arch.sha\n  done\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clair-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n",
+              "environment": {
+                "container": "get-image-manifests",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n# shellcheck source=/utils.sh\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\n\n# the quay report format used by the Conftest rules in the\n# conftest-vulnerabilities step doesn't contain the \"issued\" date which\n# we require in the policy rules, so we resort to running clair-action\n# twice to produce both quay and clair formatted output\nclair_report() {\n  { retry clair-action report --image-ref=\"$1\" --db-path=/tmp/matcher.db --format=clair | tee  \"clair-report-$2.json\"; } && \\\n  { retry clair-action convert  --file-path=\"clair-report-$2.json\" --format=quay > \"clair-result-$2.json\"; }\n}\n\nrun_clair_on_arch() {\n  local arch=\"$1\"\n  local sha_file=\"image-manifest-$arch.sha\"\n\n  if [ -e \"$sha_file\" ]; then\n    local arch_sha\n    arch_sha=$(<\"$sha_file\")\n    local digest=\"${imagewithouttag}@${arch_sha}\"\n\n    echo \"Running clair-action on $arch image manifest...\"\n    clair_report \"$digest\" \"$arch\" || true\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n   fi\n}\n\nplatform=\"${IMAGE_PLATFORM}\"\n\n# If a platform is specified, extract the architecture and run clair-action on the corresponding image manifest\nif [ -n \"$platform\" ]; then\n  arch=\"${platform#*/}\"\n  if [ \"$arch\" = \"x86_64\" ] || [ \"$arch\" = \"local\" ] || [ \"$arch\" = \"localhost\" ]; then\n    arch=\"amd64\"\n  fi\n  # Validate against supported arch list. If it's not a known arch, fallback to amd64\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      echo \"Error: Unsupported or malformed architecture: '$arch' (parsed from platform: '$platform')\"\n      exit 0\n      ;;\n  esac\n\n  run_clair_on_arch \"$arch\"\n\n# If no platform is specified, run clair-action on all available image manifests\nelse\n  for sha_file in image-manifest-*.sha; do\n    if [ -e \"$sha_file\" ]; then\n      arch=$(basename \"$sha_file\" | sed 's/image-manifest-//;s/.sha//')\n      run_clair_on_arch \"$arch\"\n    fi\n  done\nfi\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\n\nimages_processed=$(echo \"${images_processed_template/\\[%s]/[$digests_processed_string]}\")\necho \"$images_processed\" > images-processed.json\n",
+              "environment": {
+                "container": "get-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/clair-in-ci@sha256:6386cbb69b5ddf94168f9397a8795365f4d7500103e15ec8f6bd256afd75a33b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nif ! compgen -G \"clair-report-*.json\" > /dev/null; then\n  echo 'No Clair reports generated. Skipping upload.'\n  exit 0\nfi\n\necho \"Selecting auth\"\nselect-oci-auth \"$IMAGE_URL\" > \"$HOME/auth.json\"\n\nrepository=\"${IMAGE_URL/:*/}\"\n\narch() {\n  report_file=\"$1\"\n  arch=\"${report_file/*-}\"\n  echo \"${arch/.json/}\"\n}\n\nMEDIA_TYPE='application/vnd.redhat.clair-report+json'\n\nreports_json=\"\"\nfor f in clair-report-*.json; do\n  digest=$(cat \"image-manifest-$(arch \"$f\").sha\")\n  image_ref=\"${repository}@${digest}\"\n  echo \"Attaching $f to ${image_ref}\"\n  if ! report_digest=\"$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \\\n    \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${image_ref}\" \"$f:${MEDIA_TYPE}\")\"\n  then\n    echo \"Failed to attach ${f} to ${image_ref}\"\n    exit 1\n  fi\n  # shellcheck disable=SC2016\n  reports_json=\"$(yq --output-format json --indent=0 eval-all '. as $i ireduce ({}; . * $i)' <(echo \"${reports_json}\") <(echo \"${digest}: ${report_digest}\"))\"\ndone\necho \"${reports_json}\" > reports.json\n",
+              "environment": {
+                "container": "oci-attach-report",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nclair_result_files=$(ls /tekton/home/clair-result-*.json)\nif [ -z \"$clair_result_files\" ]; then\n  echo \"Previous step [get-vulnerabilities] failed: No clair-result files found in /tekton/home.\"\nfi\n\nmissing_vulnerabilities_files=\"\"\nfor file in $clair_result_files; do\n  file_suffix=$(basename \"$file\" | sed 's/clair-result-//;s/.json//')\n  if [ ! -s \"$file\" ]; then\n    echo \"Previous step [get-vulnerabilities] failed: $file is empty.\"\n  else\n    /usr/bin/conftest test --no-fail $file \\\n    --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \\\n    --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true\n  fi\n\n  #check for missing \"clair-vulnerabilities-<arch>/image-index\" file and create a string\n  if [ ! -f \"/tekton/home/clair-vulnerabilities-$file_suffix.json\" ]; then\n    missing_vulnerabilities_files+=\"${missing_vulnerabilities_files:+, }/tekton/home/clair-vulnerabilities-$file_suffix.json\"\n  fi\ndone\n\nif [ -n \"$missing_vulnerabilities_files\" ]; then\n  note=\"Task clair-scan failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log.\"\n  TEST_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log.\"\n  echo \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\nscan_result='{\"vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}, \"unpatched_vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}}'\nfor file in /tekton/home/clair-vulnerabilities-*.json; do\n    result=$(jq -rce \\\n        '{\n            vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            },\n            unpatched_vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            }\n        }' \"$file\")\n\n    scan_result=$(jq -s -rce \\\n          '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |\n          .[0].vulnerabilities.high += .[1].vulnerabilities.high |\n          .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |\n          .[0].vulnerabilities.low += .[1].vulnerabilities.low |\n          .[0].vulnerabilities.unknown += .[1].vulnerabilities.unknown |\n          .[0].unpatched_vulnerabilities.critical += .[1].unpatched_vulnerabilities.critical |\n          .[0].unpatched_vulnerabilities.high += .[1].unpatched_vulnerabilities.high |\n          .[0].unpatched_vulnerabilities.medium += .[1].unpatched_vulnerabilities.medium |\n          .[0].unpatched_vulnerabilities.low += .[1].unpatched_vulnerabilities.low |\n          .[0].unpatched_vulnerabilities.unknown += .[1].unpatched_vulnerabilities.unknown |\n          .[0]' <<<\"$scan_result $result\")\ndone\n\necho \"$scan_result\" | tee \"/tekton/results/SCAN_OUTPUT\"\n\ncat /tekton/home/images-processed.json | tee /tekton/results/IMAGES_PROCESSED\n# shellcheck disable=SC2154\ncat /tekton/home/reports.json > \"/tekton/results/REPORTS\"\n\nnote=\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\"\nTEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n",
+              "environment": {
+                "container": "conftest-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:12Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              "entryPoint": "clair-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clair-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/66879ba5-f0e9-4f27-95b8-de5422afdc69",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-f9ecbe07f2a26af8-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clair-scan",
+                "tekton.dev/task": "clair-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "docker-auth": "",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-platform": "linux/s390x",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clair-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clair-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "REPORTS",
+              "type": "string",
+              "value": "{\"sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c\":\"sha256:a3fe55afb2fc156e2bc4457926053761bb57a054bbd959a20e589af86ff42d0c\"}\n"
+            },
+            {
+              "name": "SCAN_OUTPUT",
+              "type": "string",
+              "value": "{\"vulnerabilities\":{\"critical\":0,\"high\":0,\"medium\":0,\"low\":0,\"unknown\":0},\"unpatched_vulnerabilities\":{\"critical\":0,\"high\":5,\"medium\":24,\"low\":37,\"unknown\":0}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:01:11+00:00\",\"note\":\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n# shellcheck source=/dev/null\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\necho \"Inspecting raw image manifest $imageanddigest.\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\nif [ -n \"$image_manifests\" ]; then\n  echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"' | while read -r arch arch_sha; do\n    echo \"$arch_sha\" > /tekton/home/image-manifest-$arch.sha\n  done\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clair-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n",
+              "environment": {
+                "container": "get-image-manifests",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n# shellcheck source=/utils.sh\n. /utils.sh\n\nimagewithouttag=$(echo -n $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\")\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\n\n# the quay report format used by the Conftest rules in the\n# conftest-vulnerabilities step doesn't contain the \"issued\" date which\n# we require in the policy rules, so we resort to running clair-action\n# twice to produce both quay and clair formatted output\nclair_report() {\n  { retry clair-action report --image-ref=\"$1\" --db-path=/tmp/matcher.db --format=clair | tee  \"clair-report-$2.json\"; } && \\\n  { retry clair-action convert  --file-path=\"clair-report-$2.json\" --format=quay > \"clair-result-$2.json\"; }\n}\n\nrun_clair_on_arch() {\n  local arch=\"$1\"\n  local sha_file=\"image-manifest-$arch.sha\"\n\n  if [ -e \"$sha_file\" ]; then\n    local arch_sha\n    arch_sha=$(<\"$sha_file\")\n    local digest=\"${imagewithouttag}@${arch_sha}\"\n\n    echo \"Running clair-action on $arch image manifest...\"\n    clair_report \"$digest\" \"$arch\" || true\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n   fi\n}\n\nplatform=\"${IMAGE_PLATFORM}\"\n\n# If a platform is specified, extract the architecture and run clair-action on the corresponding image manifest\nif [ -n \"$platform\" ]; then\n  arch=\"${platform#*/}\"\n  if [ \"$arch\" = \"x86_64\" ] || [ \"$arch\" = \"local\" ] || [ \"$arch\" = \"localhost\" ]; then\n    arch=\"amd64\"\n  fi\n  # Validate against supported arch list. If it's not a known arch, fallback to amd64\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      echo \"Error: Unsupported or malformed architecture: '$arch' (parsed from platform: '$platform')\"\n      exit 0\n      ;;\n  esac\n\n  run_clair_on_arch \"$arch\"\n\n# If no platform is specified, run clair-action on all available image manifests\nelse\n  for sha_file in image-manifest-*.sha; do\n    if [ -e \"$sha_file\" ]; then\n      arch=$(basename \"$sha_file\" | sed 's/image-manifest-//;s/.sha//')\n      run_clair_on_arch \"$arch\"\n    fi\n  done\nfi\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\n\nimages_processed=$(echo \"${images_processed_template/\\[%s]/[$digests_processed_string]}\")\necho \"$images_processed\" > images-processed.json\n",
+              "environment": {
+                "container": "get-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/clair-in-ci@sha256:6386cbb69b5ddf94168f9397a8795365f4d7500103e15ec8f6bd256afd75a33b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nif ! compgen -G \"clair-report-*.json\" > /dev/null; then\n  echo 'No Clair reports generated. Skipping upload.'\n  exit 0\nfi\n\necho \"Selecting auth\"\nselect-oci-auth \"$IMAGE_URL\" > \"$HOME/auth.json\"\n\nrepository=\"${IMAGE_URL/:*/}\"\n\narch() {\n  report_file=\"$1\"\n  arch=\"${report_file/*-}\"\n  echo \"${arch/.json/}\"\n}\n\nMEDIA_TYPE='application/vnd.redhat.clair-report+json'\n\nreports_json=\"\"\nfor f in clair-report-*.json; do\n  digest=$(cat \"image-manifest-$(arch \"$f\").sha\")\n  image_ref=\"${repository}@${digest}\"\n  echo \"Attaching $f to ${image_ref}\"\n  if ! report_digest=\"$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \\\n    \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${image_ref}\" \"$f:${MEDIA_TYPE}\")\"\n  then\n    echo \"Failed to attach ${f} to ${image_ref}\"\n    exit 1\n  fi\n  # shellcheck disable=SC2016\n  reports_json=\"$(yq --output-format json --indent=0 eval-all '. as $i ireduce ({}; . * $i)' <(echo \"${reports_json}\") <(echo \"${digest}: ${report_digest}\"))\"\ndone\necho \"${reports_json}\" > reports.json\n",
+              "environment": {
+                "container": "oci-attach-report",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nclair_result_files=$(ls /tekton/home/clair-result-*.json)\nif [ -z \"$clair_result_files\" ]; then\n  echo \"Previous step [get-vulnerabilities] failed: No clair-result files found in /tekton/home.\"\nfi\n\nmissing_vulnerabilities_files=\"\"\nfor file in $clair_result_files; do\n  file_suffix=$(basename \"$file\" | sed 's/clair-result-//;s/.json//')\n  if [ ! -s \"$file\" ]; then\n    echo \"Previous step [get-vulnerabilities] failed: $file is empty.\"\n  else\n    /usr/bin/conftest test --no-fail $file \\\n    --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \\\n    --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true\n  fi\n\n  #check for missing \"clair-vulnerabilities-<arch>/image-index\" file and create a string\n  if [ ! -f \"/tekton/home/clair-vulnerabilities-$file_suffix.json\" ]; then\n    missing_vulnerabilities_files+=\"${missing_vulnerabilities_files:+, }/tekton/home/clair-vulnerabilities-$file_suffix.json\"\n  fi\ndone\n\nif [ -n \"$missing_vulnerabilities_files\" ]; then\n  note=\"Task clair-scan failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log.\"\n  TEST_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log.\"\n  echo \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\nscan_result='{\"vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}, \"unpatched_vulnerabilities\":{\"critical\":0, \"high\":0, \"medium\":0, \"low\":0, \"unknown\":0}}'\nfor file in /tekton/home/clair-vulnerabilities-*.json; do\n    result=$(jq -rce \\\n        '{\n            vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            },\n            unpatched_vulnerabilities:{\n              critical: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_critical_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              high: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_high_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              medium: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_medium_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              low: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_low_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0),\n              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name==\"clair_unpatched_unknown_vulnerabilities\").metadata.\"vulnerabilities_number\" // 0)| add // 0)\n            }\n        }' \"$file\")\n\n    scan_result=$(jq -s -rce \\\n          '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |\n          .[0].vulnerabilities.high += .[1].vulnerabilities.high |\n          .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |\n          .[0].vulnerabilities.low += .[1].vulnerabilities.low |\n          .[0].vulnerabilities.unknown += .[1].vulnerabilities.unknown |\n          .[0].unpatched_vulnerabilities.critical += .[1].unpatched_vulnerabilities.critical |\n          .[0].unpatched_vulnerabilities.high += .[1].unpatched_vulnerabilities.high |\n          .[0].unpatched_vulnerabilities.medium += .[1].unpatched_vulnerabilities.medium |\n          .[0].unpatched_vulnerabilities.low += .[1].unpatched_vulnerabilities.low |\n          .[0].unpatched_vulnerabilities.unknown += .[1].unpatched_vulnerabilities.unknown |\n          .[0]' <<<\"$scan_result $result\")\ndone\n\necho \"$scan_result\" | tee \"/tekton/results/SCAN_OUTPUT\"\n\ncat /tekton/home/images-processed.json | tee /tekton/results/IMAGES_PROCESSED\n# shellcheck disable=SC2154\ncat /tekton/home/reports.json > \"/tekton/results/REPORTS\"\n\nnote=\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\"\nTEST_OUTPUT=$(make_result_json -r \"SUCCESS\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee /tekton/results/TEST_OUTPUT\n",
+              "environment": {
+                "container": "conftest-vulnerabilities",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index",
+            "prefetch-dependencies"
+          ],
+          "finishedOn": "2025-09-24T08:04:32Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "783f5de1b4def2fb3fad20b914f4b3afee46ffb8f652114946e321ef3fa86449"
+              },
+              "entryPoint": "sast-snyk-check-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/ffbbc823-6dfc-4a11-8f02-3b5132511a70",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-61899dd4fb862503-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "sast-snyk-check",
+                "tekton.dev/task": "sast-snyk-check-oci-ta"
+              }
+            },
+            "parameters": {
+              "ARGS": "",
+              "CACHI2_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007",
+              "IGNORE_FILE_PATHS": "",
+              "IMP_FINDINGS_ONLY": "true",
+              "KFP_GIT_URL": "SITE_DEFAULT",
+              "PROJECT_NAME": "",
+              "RECORD_EXCLUDED": "false",
+              "SNYK_SECRET": "snyk-secret",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7",
+              "TARGET_DIRS": ".",
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "sast-snyk-check",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "sast-snyk-check-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:783f5de1b4def2fb3fad20b914f4b3afee46ffb8f652114946e321ef3fa86449"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:04:30+00:00\",\"note\":\"For details, check Tekton task log.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7=/var/workdir/source",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007=/var/workdir/cachi2"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nset -euo pipefail\n# shellcheck source=/dev/null\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nif [[ -z \"${PROJECT_NAME}\" ]]; then\n  PROJECT_NAME=${COMPONENT_LABEL}\nfi\n\necho \"INFO: The PROJECT_NAME used is: ${PROJECT_NAME}\"\n\n# Installation of Red Hat certificates for cloning Red Hat internal repositories\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\nSNYK_TOKEN_PATH=\"/etc/secrets/snyk_token\"\nif [ -f \"${SNYK_TOKEN_PATH}\" ] && [ -s \"${SNYK_TOKEN_PATH}\" ]; then\n  # SNYK token is provided\n  SNYK_TOKEN=\"$(cat ${SNYK_TOKEN_PATH})\"\n  export SNYK_TOKEN\nelse\n  # According to shellcheck documentation, the following error can be ignored as it is ignored through indirection: https://www.shellcheck.net/wiki/SC2034\n  # shellcheck disable=SC2034\n  to_enable_snyk='[here](https://konflux-ci.dev/docs/testing/build/snyk/)'\n  note=\"Task sast-snyk-check-oci-ta skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key 'snyk_token' containing the Snyk token by following the steps given ${to_enable_snyk}\"\n  TEST_OUTPUT=$(make_result_json -r SKIPPED -t \"$note\")\n  echo \"${TEST_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\nSNYK_EXIT_CODE=0\nSOURCE_CODE_DIR=/var/workdir\nSEVERITY_THRESHOLD=\"high\"\nif [ \"${IMP_FINDINGS_ONLY}\" == \"false\" ]; then\n  SEVERITY_THRESHOLD=\"low\"\nfi\n\n# We ignore files using snyk ignore if the user set up the IGNORE_FILE_PATHS variable.\n(cd \"${SOURCE_CODE_DIR}\" && IFS=\",\" && for path in $IGNORE_FILE_PATHS; do\n  snyk ignore --file-path=\"source/${path}\"\ndone)\n\nset +e\necho \"INFO: Running 'snyk code test'..\"\n# We do want to expand ARGS (it can be multiple CLI flags, not just one)\n# shellcheck disable=SC2086\n\n# Generate full paths for each directory in TARGET_DIRS\nIFS=\",\" read -ra TARGETS_ARRAY <<<\"$TARGET_DIRS\"\nfor d in \"${TARGETS_ARRAY[@]}\"; do\n  potential_path=\"${SOURCE_CODE_DIR}/${d}\"\n  resolved_path=$(realpath -m \"$potential_path\")\n\n  # Ensure resolved path is still within SOURCE_CODE_DIR\n  if [[ ! \"$resolved_path\" == \"$SOURCE_CODE_DIR\"* ]]; then\n    echo \"Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'\"\n    exit 1\n  fi\n\n  # Ensure directory exists\n  if [ ! -d \"$resolved_path\" ]; then\n    echo \"Warning: Directory $resolved_path does not exist, skipping\"\n    continue\n  fi\n\n  echo \"INFO: Scanning directory: $resolved_path\"\n  # We do want to expand ARGS (it can be multiple CLI flags, not just one)\n  # shellcheck disable=SC2086\n  snyk code test $ARGS --severity-threshold=\"$SEVERITY_THRESHOLD\" \"$resolved_path\" --max-depth=1 --sarif-file-output=\"${resolved_path}/sast_snyk_check_out_${d//\\//_}.json\" 1>&2 >>stdout.txt || true\ndone\n\n# Merge all SARIF outputs\nfind \"$SOURCE_CODE_DIR\" -name \"sast_snyk_check_out_*.json\" -exec cat {} + >\"${SOURCE_CODE_DIR}/sast_snyk_check_out.json\"\n\nSNYK_EXIT_CODE=$?\nset -e\ntest_not_skipped=0\nSKIP_MSG=\"We found 0 supported files\"\ngrep -q \"$SKIP_MSG\" stdout.txt || test_not_skipped=$?\n\nif [[ \"$SNYK_EXIT_CODE\" -eq 0 ]] || [[ \"$SNYK_EXIT_CODE\" -eq 1 ]]; then\n  # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context\n  (cd \"${SOURCE_CODE_DIR}\" && csgrep --mode=json --embed-context=3 \"${SOURCE_CODE_DIR}\"/sast_snyk_check_out.json) |\n    csgrep --mode=json --strip-path-prefix=\"source/\" \\\n      >sast_snyk_check_out_all_findings.json\n\n  echo \"INFO: Initial results:\"\n  csgrep --mode=evtstat sast_snyk_check_out_all_findings.json\n\n  if [[ \"${KFP_GIT_URL}\" == \"SITE_DEFAULT\" ]]; then\n    KFP_GIT_URL=\"https://gitlab.cee.redhat.com/osh/known-false-positives.git\"\n  fi\n  PROBE_URL=\"${KFP_GIT_URL%.git}\" # trims '.git' suffix\n\n  # create the KFP clone directory regardless\n  KFP_DIR=\"known-false-positives\"\n  KFP_CLONED=\"0\"\n  mkdir \"${KFP_DIR}\"\n\n  # We check if the KFP_GIT_URL variable is set to clone and apply the filters or not\n  if [[ -n \"${KFP_GIT_URL}\" ]]; then\n    # Default location only reachable from internal Konflux instances, check reachable first\n    echo -n \"INFO: Probing ${PROBE_URL}... \"\n    if curl --fail --head --max-time 60 --no-progress-meter \"${PROBE_URL}\" > >(head -1); then\n      echo \"INFO: Trying to clone known-false-positives..\"\n      git clone \"${KFP_GIT_URL}\" \"${KFP_DIR}\" && KFP_CLONED=\"1\"\n    fi\n  fi\n\n  if [[ \"${KFP_CLONED}\" -eq \"0\" ]]; then\n    echo \"WARN: Failed to clone know-false-positives at ${KFP_GIT_URL}, scan results will not be filtered\"\n    mv sast_snyk_check_out_all_findings.json filtered_sast_snyk_check_out.json\n  else\n    echo \"INFO: Filtering false positives in results files using csfilter-kfp...\"\n\n    CMD=(\n      csfilter-kfp\n      --verbose\n      --kfp-dir=\"${KFP_DIR}\"\n      --project-nvr=\"${PROJECT_NAME}\"\n    )\n\n    if [ \"${RECORD_EXCLUDED}\" == \"true\" ]; then\n      CMD+=(--record-excluded=\"excluded-findings.json\")\n    fi\n\n    set +e\n    \"${CMD[@]}\" sast_snyk_check_out_all_findings.json >filtered_sast_snyk_check_out.json\n    status=$?\n    set -e\n    if [ \"$status\" -ne 0 ]; then\n      echo \"WARN: failed to filter known false positives\" >&2\n    else\n      echo \"INFO: Succeeded filtering known false positives\" >&2\n    fi\n    echo \"INFO: Results after filtering:\"\n    (set -x && csgrep --mode=evtstat filtered_sast_snyk_check_out.json)\n  fi\n\n  # Generation of scan stats\n\n  total_files=$(jq '[.runs[0].properties.coverage[].files] | add' \"${SOURCE_CODE_DIR}\"/sast_snyk_check_out.json)\n  supported_files=$(jq '[.runs[0].properties.coverage[] | select(.type == \"SUPPORTED\") | .files] | add' \"${SOURCE_CODE_DIR}\"/sast_snyk_check_out.json)\n\n  # We make sure the values are 0 if no supported/total files are found\n  if [ \"$total_files\" = \"null\" ] || [ -z \"$total_files\" ]; then\n    total_files=0\n  fi\n\n  if [ \"$supported_files\" = \"null\" ] || [ -z \"$supported_files\" ]; then\n    supported_files=0\n  fi\n\n  coverage_ratio=0\n  if ((total_files > 0)); then\n    coverage_ratio=$((supported_files * 100 / total_files))\n  fi\n\n  # embed stats in results file and convert to SARIF\n  csgrep --mode=sarif --set-scan-prop snyk-scanned-files-coverage:\"${coverage_ratio}\" \\\n    --set-scan-prop snyk-scanned-files-success:\"${supported_files}\" \\\n    --set-scan-prop snyk-scanned-files-total:\"${total_files}\" \\\n    filtered_sast_snyk_check_out.json >sast_snyk_check_out.sarif\n\n  TEST_OUTPUT=\n  parse_test_output \"sast-snyk-check-oci-ta\" sarif sast_snyk_check_out.sarif || true\n\n# When the test is skipped, the \"SNYK_EXIT_CODE\" is 3 and it can also be 3 in some other situation\nelif [[ \"$test_not_skipped\" -eq 0 ]]; then\n  note=\"Task sast-snyk-check-oci-ta success: Snyk code test found zero supported files.\"\n  ERROR_OUTPUT=$(make_result_json -r SUCCESS -t \"$note\")\nelse\n  echo \"sast-snyk-check test failed because of the following issues:\"\n  cat stdout.txt\n  note=\"Task sast-snyk-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee \"/tekton/results/TEST_OUTPUT\"\n",
+              "environment": {
+                "container": "sast-snyk-check",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nif [ -z \"${IMAGE_URL}\" ]; then\n  echo 'No image-url provided. Skipping upload.'\n  exit 0\nfi\n\nUPLOAD_FILES=\"sast_snyk_check_out.sarif excluded-findings.json\"\nfor UPLOAD_FILE in ${UPLOAD_FILES}; do\n  if [ ! -f \"${UPLOAD_FILE}\" ]; then\n    echo \"No ${UPLOAD_FILE} exists. Skipping upload.\"\n    continue\n  fi\n  if [ \"${UPLOAD_FILES}\" == \"excluded-findings.json\" ]; then\n    MEDIA_TYPE=application/json\n  else\n    MEDIA_TYPE=application/sarif+json\n  fi\n  echo \"Selecting auth\"\n  select-oci-auth \"${IMAGE_URL}\" >\"${HOME}/auth.json\"\n  echo \"Attaching to ${IMAGE_URL}\"\n  if ! retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${UPLOAD_FILE}:${MEDIA_TYPE}\"; then\n    echo \"Failed to attach to ${IMAGE_URL}\"\n  fi\ndone\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:26Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              "entryPoint": "clamav-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/50b68a5e-7e05-4765-ade1-31056d322923",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "virus, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-3597794e62d8a318-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clamav-scan",
+                "tekton.dev/task": "clamav-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "clamd-max-threads": "8",
+              "docker-auth": "",
+              "image-arch": "linux/ppc64le",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clamav-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clamav-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"timestamp\":\"1758700884\",\"namespace\":\"required_checks\",\"successes\":2,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\",\"note\":\"All checks passed successfully\"}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\n# Start clamd in background\n/start-clamd.sh\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\n# check if image is attestation one, skip the clamav scan in such case\nif [[ $imageanddigest == *.att ]]\nthen\n    echo \"$imageanddigest is an attestation image. Skipping ClamAV scan.\"\n    exit 0\nfi\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\nmkdir logs\nmkdir content\ncd content\necho \"Extracting image(s).\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\n# Proceed only if a specific arch is provided.\n# This typically occurs when using Tekton Matrix to launch multiple TaskRuns to scan all architectures of a multi-arch image in parallel.\nif [ -n \"$IMAGE_ARCH\" ]; then\n  arch=\"${IMAGE_ARCH#*/}\"\n  if [ \"${arch}\" = \"x86_64\" ]; then\n    arch=\"amd64\"\n  fi\n\n  # Check if arch is supported; if not (e.g., it's 'local', see link below), default to amd64.\n  # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml#L9-L14\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      arch=\"amd64\"\n      ;;\n  esac\n\n  image_manifests=$(echo \"$image_manifests\" | jq -c --arg arch \"$arch\" '{($arch): .[$arch]}')\nfi\n\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    destination=$(echo content-$arch)\n    mkdir -p \"$destination\"\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n\n    echo \"Running \\\"oc image extract\\\" on image of arch $arch\"\n    retry oc image extract --only-files=true --registry-config ~/.docker/config.json \"$arch_imageanddigest\" --path=\"/:${destination}\" --filter-by-os=\"linux/${arch}\"\n    if [ $? -ne 0 ]; then\n      echo \"Unable to extract image for arch $arch. Skipping ClamAV scan!\"\n      exit 0\n    fi\n\n    db_version=$(clamdscan --version | sed 's|.*/\\(.*\\)/.*|\\1|')\n\n    echo \"Scanning image for arch $arch. This operation may take a while.\"\n    clamdscan \"${destination}\" -vi --multiscan --fdpass \\\n      | tee /work/logs/clamscan-result-$arch.log || true\n\n    echo \"Executed-on: Scan was executed on clamsdcan version - $(clamdscan --version) Database version: $db_version\" | tee -a \"/work/logs/clamscan-result-$arch.log\"\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n\n    if [[ -e \"/work/logs/clamscan-result-$arch.log\" ]]; then\n      # file_suffix=$(basename \"$file\" | sed 's/clamscan-result-//;s/.log//')\n      # OPA/EC requires structured data input, add clamAV log into json\n      jq -Rs '{ output: . }' /work/logs/clamscan-result-$arch.log > /work/logs/clamscan-result-log-$arch.json\n\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o json \\\n        /work/logs/clamscan-result-log-$arch.json || true\n\n      # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o appstudio \\\n        /work/logs/clamscan-result-log-$arch.json | tee /work/logs/clamscan-ec-test-$arch.json || true\n\n      cat /work/logs/clamscan-ec-test-$arch.json\n    fi\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clamav-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\njq -s -rce '\n  reduce .[] as $item ({\"timestamp\":\"0\",\"namespace\":\"\",\"successes\":0,\"failures\":0,\"warnings\":0,\"result\":\"\",\"note\":\"\"};\n    {\n    \"timestamp\" : (if .timestamp < $item.timestamp then $item.timestamp else .timestamp end),\n    \"namespace\" : $item.namespace,\n    \"successes\" : (.successes + $item.successes),\n    \"failures\" : (.failures + $item.failures),\n    \"warnings\" : (.warnings + $item.warnings),\n    \"result\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.result else .result end),\n    \"note\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.note else .note end)\n    })' /work/logs/clamscan-ec-test-*.json | tee /tekton/results/TEST_OUTPUT\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
+              "environment": {
+                "container": "extract-and-scan-image",
+                "image": "oci://quay.io/konflux-ci/clamav-db@sha256:1a3eb068f26dae6f8fc6991d72f38cbf553e06aef38b36ac23428a990be8f282"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -e\n\n# Don't return a glob expression when no matches are found\nshopt -s nullglob\n\ncd logs\n\nfor UPLOAD_FILE in clamscan-result*.log; do\n  MEDIA_TYPE=text/vnd.clamav\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\nfor UPLOAD_FILE in clamscan-ec-test*.json; do\n  MEDIA_TYPE=application/vnd.konflux.test_output+json\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\n\nif [ -z \"${args}\" ]; then\n  echo \"No files found. Skipping upload.\"\n  exit 0;\nfi\n\necho \"Selecting auth\"\nselect-oci-auth $IMAGE_URL > $HOME/auth.json\necho \"Attaching to ${IMAGE_URL}\"\n retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type application/vnd.clamav \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${args[@]}\"\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:27Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              "entryPoint": "clamav-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/ad6135a4-f225-46b1-b36b-8a6d5d6db51d",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "virus, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-e75c221b5a17475b-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clamav-scan",
+                "tekton.dev/task": "clamav-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "clamd-max-threads": "8",
+              "docker-auth": "",
+              "image-arch": "linux/s390x",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clamav-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clamav-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"timestamp\":\"1758700885\",\"namespace\":\"required_checks\",\"successes\":2,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\",\"note\":\"All checks passed successfully\"}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\n# Start clamd in background\n/start-clamd.sh\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\n# check if image is attestation one, skip the clamav scan in such case\nif [[ $imageanddigest == *.att ]]\nthen\n    echo \"$imageanddigest is an attestation image. Skipping ClamAV scan.\"\n    exit 0\nfi\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\nmkdir logs\nmkdir content\ncd content\necho \"Extracting image(s).\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\n# Proceed only if a specific arch is provided.\n# This typically occurs when using Tekton Matrix to launch multiple TaskRuns to scan all architectures of a multi-arch image in parallel.\nif [ -n \"$IMAGE_ARCH\" ]; then\n  arch=\"${IMAGE_ARCH#*/}\"\n  if [ \"${arch}\" = \"x86_64\" ]; then\n    arch=\"amd64\"\n  fi\n\n  # Check if arch is supported; if not (e.g., it's 'local', see link below), default to amd64.\n  # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml#L9-L14\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      arch=\"amd64\"\n      ;;\n  esac\n\n  image_manifests=$(echo \"$image_manifests\" | jq -c --arg arch \"$arch\" '{($arch): .[$arch]}')\nfi\n\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    destination=$(echo content-$arch)\n    mkdir -p \"$destination\"\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n\n    echo \"Running \\\"oc image extract\\\" on image of arch $arch\"\n    retry oc image extract --only-files=true --registry-config ~/.docker/config.json \"$arch_imageanddigest\" --path=\"/:${destination}\" --filter-by-os=\"linux/${arch}\"\n    if [ $? -ne 0 ]; then\n      echo \"Unable to extract image for arch $arch. Skipping ClamAV scan!\"\n      exit 0\n    fi\n\n    db_version=$(clamdscan --version | sed 's|.*/\\(.*\\)/.*|\\1|')\n\n    echo \"Scanning image for arch $arch. This operation may take a while.\"\n    clamdscan \"${destination}\" -vi --multiscan --fdpass \\\n      | tee /work/logs/clamscan-result-$arch.log || true\n\n    echo \"Executed-on: Scan was executed on clamsdcan version - $(clamdscan --version) Database version: $db_version\" | tee -a \"/work/logs/clamscan-result-$arch.log\"\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n\n    if [[ -e \"/work/logs/clamscan-result-$arch.log\" ]]; then\n      # file_suffix=$(basename \"$file\" | sed 's/clamscan-result-//;s/.log//')\n      # OPA/EC requires structured data input, add clamAV log into json\n      jq -Rs '{ output: . }' /work/logs/clamscan-result-$arch.log > /work/logs/clamscan-result-log-$arch.json\n\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o json \\\n        /work/logs/clamscan-result-log-$arch.json || true\n\n      # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o appstudio \\\n        /work/logs/clamscan-result-log-$arch.json | tee /work/logs/clamscan-ec-test-$arch.json || true\n\n      cat /work/logs/clamscan-ec-test-$arch.json\n    fi\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clamav-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\njq -s -rce '\n  reduce .[] as $item ({\"timestamp\":\"0\",\"namespace\":\"\",\"successes\":0,\"failures\":0,\"warnings\":0,\"result\":\"\",\"note\":\"\"};\n    {\n    \"timestamp\" : (if .timestamp < $item.timestamp then $item.timestamp else .timestamp end),\n    \"namespace\" : $item.namespace,\n    \"successes\" : (.successes + $item.successes),\n    \"failures\" : (.failures + $item.failures),\n    \"warnings\" : (.warnings + $item.warnings),\n    \"result\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.result else .result end),\n    \"note\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.note else .note end)\n    })' /work/logs/clamscan-ec-test-*.json | tee /tekton/results/TEST_OUTPUT\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
+              "environment": {
+                "container": "extract-and-scan-image",
+                "image": "oci://quay.io/konflux-ci/clamav-db@sha256:1a3eb068f26dae6f8fc6991d72f38cbf553e06aef38b36ac23428a990be8f282"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -e\n\n# Don't return a glob expression when no matches are found\nshopt -s nullglob\n\ncd logs\n\nfor UPLOAD_FILE in clamscan-result*.log; do\n  MEDIA_TYPE=text/vnd.clamav\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\nfor UPLOAD_FILE in clamscan-ec-test*.json; do\n  MEDIA_TYPE=application/vnd.konflux.test_output+json\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\n\nif [ -z \"${args}\" ]; then\n  echo \"No files found. Skipping upload.\"\n  exit 0;\nfi\n\necho \"Selecting auth\"\nselect-oci-auth $IMAGE_URL > $HOME/auth.json\necho \"Attaching to ${IMAGE_URL}\"\n retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type application/vnd.clamav \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${args[@]}\"\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:26Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              "entryPoint": "clamav-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/98dc5bcf-a6dc-48cc-93d5-eeace4e4c0be",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "virus, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-ed0268e15f92b6f7-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clamav-scan",
+                "tekton.dev/task": "clamav-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "clamd-max-threads": "8",
+              "docker-auth": "",
+              "image-arch": "linux/x86_64",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clamav-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clamav-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"timestamp\":\"1758700883\",\"namespace\":\"required_checks\",\"successes\":2,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\",\"note\":\"All checks passed successfully\"}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\n# Start clamd in background\n/start-clamd.sh\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\n# check if image is attestation one, skip the clamav scan in such case\nif [[ $imageanddigest == *.att ]]\nthen\n    echo \"$imageanddigest is an attestation image. Skipping ClamAV scan.\"\n    exit 0\nfi\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\nmkdir logs\nmkdir content\ncd content\necho \"Extracting image(s).\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\n# Proceed only if a specific arch is provided.\n# This typically occurs when using Tekton Matrix to launch multiple TaskRuns to scan all architectures of a multi-arch image in parallel.\nif [ -n \"$IMAGE_ARCH\" ]; then\n  arch=\"${IMAGE_ARCH#*/}\"\n  if [ \"${arch}\" = \"x86_64\" ]; then\n    arch=\"amd64\"\n  fi\n\n  # Check if arch is supported; if not (e.g., it's 'local', see link below), default to amd64.\n  # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml#L9-L14\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      arch=\"amd64\"\n      ;;\n  esac\n\n  image_manifests=$(echo \"$image_manifests\" | jq -c --arg arch \"$arch\" '{($arch): .[$arch]}')\nfi\n\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    destination=$(echo content-$arch)\n    mkdir -p \"$destination\"\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n\n    echo \"Running \\\"oc image extract\\\" on image of arch $arch\"\n    retry oc image extract --only-files=true --registry-config ~/.docker/config.json \"$arch_imageanddigest\" --path=\"/:${destination}\" --filter-by-os=\"linux/${arch}\"\n    if [ $? -ne 0 ]; then\n      echo \"Unable to extract image for arch $arch. Skipping ClamAV scan!\"\n      exit 0\n    fi\n\n    db_version=$(clamdscan --version | sed 's|.*/\\(.*\\)/.*|\\1|')\n\n    echo \"Scanning image for arch $arch. This operation may take a while.\"\n    clamdscan \"${destination}\" -vi --multiscan --fdpass \\\n      | tee /work/logs/clamscan-result-$arch.log || true\n\n    echo \"Executed-on: Scan was executed on clamsdcan version - $(clamdscan --version) Database version: $db_version\" | tee -a \"/work/logs/clamscan-result-$arch.log\"\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n\n    if [[ -e \"/work/logs/clamscan-result-$arch.log\" ]]; then\n      # file_suffix=$(basename \"$file\" | sed 's/clamscan-result-//;s/.log//')\n      # OPA/EC requires structured data input, add clamAV log into json\n      jq -Rs '{ output: . }' /work/logs/clamscan-result-$arch.log > /work/logs/clamscan-result-log-$arch.json\n\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o json \\\n        /work/logs/clamscan-result-log-$arch.json || true\n\n      # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o appstudio \\\n        /work/logs/clamscan-result-log-$arch.json | tee /work/logs/clamscan-ec-test-$arch.json || true\n\n      cat /work/logs/clamscan-ec-test-$arch.json\n    fi\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clamav-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\njq -s -rce '\n  reduce .[] as $item ({\"timestamp\":\"0\",\"namespace\":\"\",\"successes\":0,\"failures\":0,\"warnings\":0,\"result\":\"\",\"note\":\"\"};\n    {\n    \"timestamp\" : (if .timestamp < $item.timestamp then $item.timestamp else .timestamp end),\n    \"namespace\" : $item.namespace,\n    \"successes\" : (.successes + $item.successes),\n    \"failures\" : (.failures + $item.failures),\n    \"warnings\" : (.warnings + $item.warnings),\n    \"result\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.result else .result end),\n    \"note\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.note else .note end)\n    })' /work/logs/clamscan-ec-test-*.json | tee /tekton/results/TEST_OUTPUT\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
+              "environment": {
+                "container": "extract-and-scan-image",
+                "image": "oci://quay.io/konflux-ci/clamav-db@sha256:1a3eb068f26dae6f8fc6991d72f38cbf553e06aef38b36ac23428a990be8f282"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -e\n\n# Don't return a glob expression when no matches are found\nshopt -s nullglob\n\ncd logs\n\nfor UPLOAD_FILE in clamscan-result*.log; do\n  MEDIA_TYPE=text/vnd.clamav\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\nfor UPLOAD_FILE in clamscan-ec-test*.json; do\n  MEDIA_TYPE=application/vnd.konflux.test_output+json\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\n\nif [ -z \"${args}\" ]; then\n  echo \"No files found. Skipping upload.\"\n  exit 0;\nfi\n\necho \"Selecting auth\"\nselect-oci-auth $IMAGE_URL > $HOME/auth.json\necho \"Attaching to ${IMAGE_URL}\"\n retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type application/vnd.clamav \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${args[@]}\"\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:25Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              "entryPoint": "clamav-scan",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/d350289f-5901-4ae1-99ab-2a5f18c60441",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "virus, konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-8e19ac385f9c603a-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "clamav-scan",
+                "tekton.dev/task": "clamav-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "clamd-max-threads": "8",
+              "docker-auth": "",
+              "image-arch": "linux/arm64",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "clamav-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "clamav-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5\",\"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"timestamp\":\"1758700883\",\"namespace\":\"required_checks\",\"successes\":2,\"failures\":0,\"warnings\":0,\"result\":\"SUCCESS\",\"note\":\"All checks passed successfully\"}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -euo pipefail\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\n# Start clamd in background\n/start-clamd.sh\n\nimagewithouttag=$(echo $IMAGE_URL | sed \"s/\\(.*\\):.*/\\1/\" | tr -d '\\n')\n\n# strip new-line escape symbol from parameter and save it to variable\nimageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)\n\n# check if image is attestation one, skip the clamav scan in such case\nif [[ $imageanddigest == *.att ]]\nthen\n    echo \"$imageanddigest is an attestation image. Skipping ClamAV scan.\"\n    exit 0\nfi\n\nimages_processed_template='{\"image\": {\"pullspec\": \"'\"$IMAGE_URL\"'\", \"digests\": [%s]}}'\ndigests_processed=()\nmkdir logs\nmkdir content\ncd content\necho \"Extracting image(s).\"\n\n# Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes\nimage_manifests=$(get_image_manifests -i \"${imageanddigest}\")\n# Proceed only if a specific arch is provided.\n# This typically occurs when using Tekton Matrix to launch multiple TaskRuns to scan all architectures of a multi-arch image in parallel.\nif [ -n \"$IMAGE_ARCH\" ]; then\n  arch=\"${IMAGE_ARCH#*/}\"\n  if [ \"${arch}\" = \"x86_64\" ]; then\n    arch=\"amd64\"\n  fi\n\n  # Check if arch is supported; if not (e.g., it's 'local', see link below), default to amd64.\n  # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml#L9-L14\n  case \"$arch\" in\n    amd64|ppc64le|arm64|s390x)\n      ;;\n    *)\n      arch=\"amd64\"\n      ;;\n  esac\n\n  image_manifests=$(echo \"$image_manifests\" | jq -c --arg arch \"$arch\" '{($arch): .[$arch]}')\nfi\n\nif [ -n \"$image_manifests\" ]; then\n  while read -r arch arch_sha; do\n    destination=$(echo content-$arch)\n    mkdir -p \"$destination\"\n    arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)\n\n    echo \"Running \\\"oc image extract\\\" on image of arch $arch\"\n    retry oc image extract --only-files=true --registry-config ~/.docker/config.json \"$arch_imageanddigest\" --path=\"/:${destination}\" --filter-by-os=\"linux/${arch}\"\n    if [ $? -ne 0 ]; then\n      echo \"Unable to extract image for arch $arch. Skipping ClamAV scan!\"\n      exit 0\n    fi\n\n    db_version=$(clamdscan --version | sed 's|.*/\\(.*\\)/.*|\\1|')\n\n    echo \"Scanning image for arch $arch. This operation may take a while.\"\n    clamdscan \"${destination}\" -vi --multiscan --fdpass \\\n      | tee /work/logs/clamscan-result-$arch.log || true\n\n    echo \"Executed-on: Scan was executed on clamsdcan version - $(clamdscan --version) Database version: $db_version\" | tee -a \"/work/logs/clamscan-result-$arch.log\"\n\n    digests_processed+=(\"\\\"$arch_sha\\\"\")\n\n    if [[ -e \"/work/logs/clamscan-result-$arch.log\" ]]; then\n      # file_suffix=$(basename \"$file\" | sed 's/clamscan-result-//;s/.log//')\n      # OPA/EC requires structured data input, add clamAV log into json\n      jq -Rs '{ output: . }' /work/logs/clamscan-result-$arch.log > /work/logs/clamscan-result-log-$arch.json\n\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o json \\\n        /work/logs/clamscan-result-log-$arch.json || true\n\n      # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again\n      EC_EXPERIMENTAL=1 ec test \\\n        --namespace required_checks \\\n        --policy /project/clamav/virus-check.rego \\\n        -o appstudio \\\n        /work/logs/clamscan-result-log-$arch.json | tee /work/logs/clamscan-ec-test-$arch.json || true\n\n      cat /work/logs/clamscan-ec-test-$arch.json\n    fi\n  done < <(echo \"$image_manifests\" | jq -r 'to_entries[] | \"\\(.key) \\(.value)\"')\nelse\n  echo \"Failed to get image manifests from image \\\"$imageanddigest\\\"\"\n  note=\"Task clamav-scan failed: Failed to get image manifests from image \\\"$imageanddigest\\\". For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r \"ERROR\" -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 0\nfi\n\njq -s -rce '\n  reduce .[] as $item ({\"timestamp\":\"0\",\"namespace\":\"\",\"successes\":0,\"failures\":0,\"warnings\":0,\"result\":\"\",\"note\":\"\"};\n    {\n    \"timestamp\" : (if .timestamp < $item.timestamp then $item.timestamp else .timestamp end),\n    \"namespace\" : $item.namespace,\n    \"successes\" : (.successes + $item.successes),\n    \"failures\" : (.failures + $item.failures),\n    \"warnings\" : (.warnings + $item.warnings),\n    \"result\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.result else .result end),\n    \"note\" : (if .result == \"\" or ($item.result == \"SKIPPED\" and .result == \"SUCCESS\") or ($item.result == \"WARNING\" and (.result == \"SUCCESS\" or .result == \"SKIPPED\")) or ($item.result == \"FAILURE\" and .result != \"ERROR\") or $item.result == \"ERROR\" then $item.note else .note end)\n    })' /work/logs/clamscan-ec-test-*.json | tee /tekton/results/TEST_OUTPUT\n\n# If the image is an Image Index, also add the Image Index digest to the list.\nif [[ \"${digests_processed[*]}\" != *\"$IMAGE_DIGEST\"* ]]; then\n  digests_processed+=(\"\\\"$IMAGE_DIGEST\\\"\")\nfi\n\ndigests_processed_string=$(IFS=,; echo \"${digests_processed[*]}\")\necho \"${images_processed_template/\\[%s]/[$digests_processed_string]}\" | tee /tekton/results/IMAGES_PROCESSED\n",
+              "environment": {
+                "container": "extract-and-scan-image",
+                "image": "oci://quay.io/konflux-ci/clamav-db@sha256:1a3eb068f26dae6f8fc6991d72f38cbf553e06aef38b36ac23428a990be8f282"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -e\n\n# Don't return a glob expression when no matches are found\nshopt -s nullglob\n\ncd logs\n\nfor UPLOAD_FILE in clamscan-result*.log; do\n  MEDIA_TYPE=text/vnd.clamav\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\nfor UPLOAD_FILE in clamscan-ec-test*.json; do\n  MEDIA_TYPE=application/vnd.konflux.test_output+json\n  args+=(\"${UPLOAD_FILE}:${MEDIA_TYPE}\")\ndone\n\nif [ -z \"${args}\" ]; then\n  echo \"No files found. Skipping upload.\"\n  exit 0;\nfi\n\necho \"Selecting auth\"\nselect-oci-auth $IMAGE_URL > $HOME/auth.json\necho \"Attaching to ${IMAGE_URL}\"\n retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type application/vnd.clamav \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${args[@]}\"\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index",
+            "prefetch-dependencies"
+          ],
+          "finishedOn": "2025-09-24T08:04:27Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "bf7bdde00b7212f730c1356672290af6f38d070da2c8a316987b5c32fd49e0b9"
+              },
+              "entryPoint": "sast-shell-check-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/d3183558-7ebe-4052-91c5-db8666438721",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-8ead4cfb2494f366-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "sast-shell-check",
+                "tekton.dev/task": "sast-shell-check-oci-ta"
+              }
+            },
+            "parameters": {
+              "CACHI2_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007",
+              "IMP_FINDINGS_ONLY": "true",
+              "KFP_GIT_URL": "SITE_DEFAULT",
+              "PROJECT_NAME": "",
+              "RECORD_EXCLUDED": "false",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7",
+              "TARGET_DIRS": ".",
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "sast-shell-check",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "sast-shell-check-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:bf7bdde00b7212f730c1356672290af6f38d070da2c8a316987b5c32fd49e0b9"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:04:25+00:00\",\"note\":\"Task sast-shell-check-oci-ta completed successfully.\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:50Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7=/var/workdir/source",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007=/var/workdir/cachi2"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -x\n# shellcheck source=/dev/null\nsource /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nif [[ -z \"${PROJECT_NAME}\" ]]; then\n  PROJECT_NAME=${COMPONENT_LABEL}\nfi\n\necho \"The PROJECT_NAME used is: ${PROJECT_NAME}\"\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\nPACKAGE_VERSION=$(rpm -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}\\n' ShellCheck)\n\nOUTPUT_FILE=\"shellcheck-results.json\"\nSOURCE_CODE_DIR=/var/workdir/source\n\n# generate full path for each dirname separated by comma\ndeclare -a ALL_TARGETS\nIFS=\",\" read -ra TARGET_ARRAY <<<\"$TARGET_DIRS\"\nfor d in \"${TARGET_ARRAY[@]}\"; do\n  potential_path=\"${SOURCE_CODE_DIR}/${d}\"\n\n  resolved_path=$(realpath -m \"$potential_path\")\n\n  # ensure resolved path is still within SOURCE_CODE_DIR\n  if [[ \"$resolved_path\" == \"$SOURCE_CODE_DIR\"* ]]; then\n    ALL_TARGETS+=(\"$resolved_path\")\n  else\n    echo \"Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'\"\n    exit 1\n  fi\ndone\n\n# determine number of available CPU cores for shellcheck based on container cgroup v2 CPU limits\n# this calculates the ceiling, so if the cpu limit is 0.5, the number of jobs will be 1.\nif [ -z \"$SC_JOBS\" ] && [ -r \"/sys/fs/cgroup/cpu.max\" ]; then\n  read -r quota period </sys/fs/cgroup/cpu.max\n  if [ \"$quota\" != \"max\" ] && [ -n \"$period\" ] && [ \"$period\" -gt 0 ]; then\n    export SC_JOBS=$(((quota + period - 1) / period))\n    echo \"INFO: Setting SC_JOBS=${SC_JOBS} based on cgroups v2 max for run-shellcheck.sh\"\n  fi\nfi\n\n# generate all shellcheck result JSON files to $SC_RESULTS_DIR, which defaults to ./shellcheck-results/\n/usr/share/csmock/scripts/run-shellcheck.sh \"${ALL_TARGETS[@]}\"\n\nCSGREP_OPTS=(\n  --mode=json\n  --strip-path-prefix=\"$SOURCE_CODE_DIR\"/\n  --remove-duplicates\n  --embed-context=3\n  --set-scan-prop=\"ShellCheck:${PACKAGE_VERSION}\"\n)\nif [[ \"$IMP_FINDINGS_ONLY\" == \"true\" ]]; then\n  # predefined list of shellcheck important findings\n  CSGREP_EVENT_FILTER='\\[SC(1020|1035|1054|1066|1068|1073|1080|1083|1099|1113|1115|1127|1128|1143|2043|2050|'\n  CSGREP_EVENT_FILTER+='2055|2057|2066|2069|2071|2077|2078|2091|2092|2157|2171|2193|2194|2195|2215|2216|'\n  CSGREP_EVENT_FILTER+='2218|2224|2225|2242|2256|2258|2261)\\]$'\n  CSGREP_OPTS+=(\n    --event=\"$CSGREP_EVENT_FILTER\"\n  )\nelse\n  CSGREP_OPTS+=(\n    --event=\"error|warning\"\n  )\nfi\n\nif ! csgrep \"${CSGREP_OPTS[@]}\" ./shellcheck-results/*.json >\"$OUTPUT_FILE\"; then\n  echo \"Error occurred while running 'run-shellcheck.sh'\"\n  note=\"Task sast-shell-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 1\nfi\n\nif [[ \"${KFP_GIT_URL}\" == \"SITE_DEFAULT\" ]]; then\n  # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances\n  PROBE_URL=\"https://gitlab.cee.redhat.com/osh/known-false-positives\"\n  echo -n \"Probing ${PROBE_URL}... \"\n  if curl --fail --head --max-time 60 --no-progress-meter \"${PROBE_URL}\" > >(head -1); then\n    echo \"Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git\"\n    KFP_GIT_URL=\"https://gitlab.cee.redhat.com/osh/known-false-positives.git\"\n  else\n    echo \"Setting KFP_GIT_URL to empty string\"\n    KFP_GIT_URL=\n  fi\nfi\n\n# Filter known false positives if KFP_GIT_URL is set\nif [ -n \"${KFP_GIT_URL}\" ]; then\n  echo \"Filtering known false positives using ${KFP_GIT_URL}\"\n\n  # build initial csfilter-kfp command\n  csfilter_kfp_cmd=(\n    csfilter-kfp\n    --verbose\n    --kfp-git-url=\"${KFP_GIT_URL}\"\n    --project-nvr=\"${PROJECT_NAME}\"\n  )\n\n  if [[ \"${RECORD_EXCLUDED}\" == \"true\" ]]; then\n    csfilter_kfp_cmd+=(--record-excluded=\"excluded-findings.json\")\n  fi\n\n  # Execute the command and capture any errors\n  if ! \"${csfilter_kfp_cmd[@]}\" \"${OUTPUT_FILE}\" >\"${OUTPUT_FILE}.filtered\" 2>\"${OUTPUT_FILE}.error\"; then\n    echo \"Error occurred while filtering known false positives:\"\n    cat \"${OUTPUT_FILE}.error\"\n    note=\"Task sast-shell-check-oci-ta failed: For details, check Tekton task log.\"\n    ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n    echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n    exit 1\n  else\n    mv \"${OUTPUT_FILE}.filtered\" \"$OUTPUT_FILE\"\n    echo \"Filtered results saved back to $OUTPUT_FILE\"\n  fi\nelse\n  echo \"KFP_GIT_URL is not set. Skipping false positive filtering.\"\nfi\n\necho \"ShellCheck results have been saved to $OUTPUT_FILE\"\n\ncsgrep --mode=evtstat \"$OUTPUT_FILE\"\ncsgrep --mode=sarif \"$OUTPUT_FILE\" >shellcheck-results.sarif\n\nnote=\"Task sast-shell-check-oci-ta completed successfully.\"\nTEST_OUTPUT=$(make_result_json -r SUCCESS -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n",
+              "environment": {
+                "container": "sast-shell-check",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:7e04a34cc9adb5fa0bfe5070d1a60321205f5e6f0cd3fb2e8a33a5ec8508fd29"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -e\n\nif [ -z \"${IMAGE_URL}\" ] || [ -z \"${IMAGE_DIGEST}\" ]; then\n  echo 'No image-url or image-digest param provided. Skipping upload.'\n  exit 0\nfi\n\nUPLOAD_FILES=\"shellcheck-results.sarif excluded-findings.json\"\n\nfor UPLOAD_FILE in ${UPLOAD_FILES}; do\n  if [ ! -f \"${UPLOAD_FILE}\" ]; then\n    echo \"No ${UPLOAD_FILE} exists. Skipping upload.\"\n    continue\n  fi\n\n  # Determine the media type based on the file extension\n  if [[ \"${UPLOAD_FILE}\" == *.json ]]; then\n    MEDIA_TYPE=\"application/json\"\n  else\n    MEDIA_TYPE=\"application/sarif+json\"\n  fi\n\n  echo \"Selecting auth\"\n  select-oci-auth \"$IMAGE_URL\" >\"$HOME/auth.json\"\n  echo \"Attaching to ${IMAGE_URL}\"\n  if ! retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${UPLOAD_FILE}:${MEDIA_TYPE}\"; then\n    echo \"Failed to attach ${UPLOAD_FILE} to ${IMAGE_URL}\"\n    exit 1\n  fi\ndone\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index",
+            "prefetch-dependencies"
+          ],
+          "finishedOn": "2025-09-24T08:04:28Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651"
+              },
+              "entryPoint": "sast-unicode-check-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/bd208735-fdb8-44d0-a6e8-29895be76d22",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-1b33d18527f486dd-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "sast-unicode-check",
+                "tekton.dev/task": "sast-unicode-check-oci-ta"
+              }
+            },
+            "parameters": {
+              "CACHI2_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007",
+              "FIND_UNICODE_CONTROL_ARGS": "-p bidi -v -d -t",
+              "FIND_UNICODE_CONTROL_GIT_URL": "https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58",
+              "KFP_GIT_URL": "SITE_DEFAULT",
+              "PROJECT_NAME": "",
+              "RECORD_EXCLUDED": "false",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7",
+              "caTrustConfigMapKey": "ca-bundle.crt",
+              "caTrustConfigMapName": "trusted-ca",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125"
+            }
+          },
+          "name": "sast-unicode-check",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "sast-unicode-check-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:04:26+00:00\",\"note\":\"Task sast-unicode-check-oci-ta success: No finding was detected\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7=/var/workdir/source",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:dbfd3e252a8f055d4b4c552a5f19d233a45bae46b622ae99c83e397493022007=/var/workdir/cachi2"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\nset -exuo pipefail\n\n# shellcheck source=/dev/null\n. /utils.sh\ntrap 'handle_error /tekton/results/TEST_OUTPUT' EXIT\n\nif [[ -z \"${PROJECT_NAME}\" ]]; then\n  PROJECT_NAME=${COMPONENT_LABEL}\nfi\n\necho \"The PROJECT_NAME used is: ${PROJECT_NAME}\"\n\nSCAN_PROP=\"\"\n\nca_bundle=/mnt/trusted-ca/ca-bundle.crt\nif [ -f \"$ca_bundle\" ]; then\n  echo \"INFO: Using mounted CA bundle: $ca_bundle\"\n  cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors\n  update-ca-trust\nfi\n\n# Clone the source code from upstream repo\nGIT_URL=$(echo \"${FIND_UNICODE_CONTROL_GIT_URL}\" | awk -F'#' '{print $1}')\nREV=$(echo \"${FIND_UNICODE_CONTROL_GIT_URL}\" | awk -F'#' '{print $2}')\n\n# Clone find-unicode-control repository\nif ! git clone \"${GIT_URL}\" find-unicode-control; then\n  echo \"Failed to clone the repository: ${GIT_URL}\" >&2\n  note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 1\nfi\n\nif [[ -n \"${REV}\" ]]; then\n  if ! git -C ./find-unicode-control/ checkout \"${REV}\"; then\n    echo \"Failed to checkout the repository: ${GIT_URL} to ${REV}\" >&2\n    note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n    ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n    echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n    exit 1\n  fi\n  SCAN_PROP=\"find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}\"\nelse\n  git_url_suffix=$(git -C ./find-unicode-control/ rev-parse HEAD)\n  SCAN_PROP=\"find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}#${git_url_suffix}\"\nfi\n\n# Find unicode control\nFUC_EXIT_CODE=0\n\n# shellcheck disable=SC2086\nLANG=en_US.utf8 ./find-unicode-control/find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} \"${SOURCE_CODE_DIR}/source\" \\\n  >raw_sast_unicode_check_out.txt \\\n  2>raw_sast_unicode_check_out.log ||\n  FUC_EXIT_CODE=$?\nif [[ \"${FUC_EXIT_CODE}\" -ne 0 ]] && [[ \"${FUC_EXIT_CODE}\" -ne 1 ]]; then\n  echo \"Failed to run find-unicode-control command\" >&2\n  cat raw_sast_unicode_check_out.log\n  note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 1\nfi\n\n# Translate the output format\nif ! sed -i raw_sast_unicode_check_out.txt -E -e 's|(.*:[0-9]+)(.*)|\\1: warning:\\2|' -e 's|^|Error: UNICONTROL_WARNING:\\n|'; then\n  echo \"Error: failed to translate the unicontrol output format\" >&2\n  note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 1\nfi\n\n# Process all results as configured with CSGERP_OPTS\nCSGERP_OPTS=(\n  --mode=json\n  --remove-duplicates\n  --embed-context=3\n  --set-scan-prop=\"${SCAN_PROP}\"\n  --strip-path-prefix=\"${SOURCE_CODE_DIR}\"/source/\n)\n# In order to generate csdiff/v1, we need to add the whole path of the source code as\n# sast-unicode-check only provides an URI to embed the context\nif ! csgrep \"${CSGERP_OPTS[@]}\" raw_sast_unicode_check_out.txt >processed_sast_unicode_check_out.json 2>processed_sast_unicode_check_out.err; then\n  echo \"Error occurred while running csgrep with CSGERP_OPTS:\"\n  cat processed_sast_unicode_check_out.err\n  note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n  echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n  exit 1\nfi\n\ncsgrep --mode=evtstat processed_sast_unicode_check_out.json\n\nif [[ \"${KFP_GIT_URL}\" == \"SITE_DEFAULT\" ]]; then\n  # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances\n  PROBE_URL=\"https://gitlab.cee.redhat.com/osh/known-false-positives\"\n  echo -n \"Probing ${PROBE_URL}... \"\n  if curl --fail --head --max-time 60 --no-progress-meter \"${PROBE_URL}\" > >(head -1); then\n    echo \"Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git\"\n    KFP_GIT_URL=\"https://gitlab.cee.redhat.com/osh/known-false-positives.git\"\n  else\n    echo \"Setting KFP_GIT_URL to empty string\"\n    KFP_GIT_URL=\n  fi\nfi\n\n# Filter known false positives if KFP_GIT_URL is set\nif [ -n \"${KFP_GIT_URL}\" ]; then\n  echo \"Filtering false positives in results files using ${KFP_GIT_URL}...\" >&2\n\n  # Build initial csfilter-kfp command\n  csfilter_kfp_cmd=(\n    csfilter-kfp\n    --verbose\n    --kfp-git-url=\"${KFP_GIT_URL}\"\n  )\n\n  # Append --project-nvr option if PROJECT_NVR is set\n  if [[ -n \"${PROJECT_NAME}\" ]]; then\n    csfilter_kfp_cmd+=(--project-nvr=\"${PROJECT_NAME}\")\n  fi\n\n  # Append --record-excluded option if RECORD_EXCLUDED is true\n  if [[ \"${RECORD_EXCLUDED}\" == \"true\" ]]; then\n    csfilter_kfp_cmd+=(--record-excluded=\"excluded-findings.json\")\n  fi\n\n  if ! \"${csfilter_kfp_cmd[@]}\" processed_sast_unicode_check_out.json >sast_unicode_check_out.json 2>sast_unicode_check_out.error; then\n    echo \"Failed to filter known false positives\" >&2\n    cat sast_unicode_check_out.error\n    note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n    ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\n    echo \"${ERROR_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\n    exit 1\n  fi\nelse\n  echo \"KFP_GIT_URL is not set. Skipping false positive filtering.\" >&2\n  mv processed_sast_unicode_check_out.json sast_unicode_check_out.json\nfi\n\n# Generate sarif report\ncsgrep --mode=sarif sast_unicode_check_out.json >sast_unicode_check_out.sarif\nif [[ \"${FUC_EXIT_CODE}\" -eq 0 ]]; then\n  note=\"Task sast-unicode-check-oci-ta success: No finding was detected\"\n  ERROR_OUTPUT=$(make_result_json -r SUCCESS -t \"$note\")\nelif [[ \"${FUC_EXIT_CODE}\" -eq 1 ]] && [[ ! -s sast_unicode_check_out.sarif ]]; then\n  note=\"Task sast-unicode-check-oci-ta success: Some findings were detected, but filtered by known false positive\"\n  ERROR_OUTPUT=$(make_result_json -r SUCCESS -t \"$note\")\nelse\n  echo \"sast-unicode-check test failed because of the following issues:\"\n  cat sast_unicode_check_out.json\n  TEST_OUTPUT=\n  parse_test_output \"sast-unicode-check-oci-ta\" sarif sast_unicode_check_out.sarif || true\n  note=\"Task sast-unicode-check-oci-ta failed: For details, check Tekton task log.\"\n  ERROR_OUTPUT=$(make_result_json -r ERROR -t \"$note\")\nfi\necho \"${TEST_OUTPUT:-${ERROR_OUTPUT}}\" | tee \"/tekton/results/TEST_OUTPUT\"\n",
+              "environment": {
+                "container": "sast-unicode-check",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/usr/bin/env bash\n\nif [ -z \"${IMAGE_URL}\" ]; then\n  echo 'No image-url param provided. Skipping upload.'\n  exit 0\nfi\n\nUPLOAD_FILES=\"sast_unicode_check_out.sarif excluded-findings.json\"\nfor UPLOAD_FILE in ${UPLOAD_FILES}; do\n  if [ ! -f \"${UPLOAD_FILE}\" ]; then\n    echo \"No ${UPLOAD_FILE} exists. Skipping upload.\"\n    continue\n  fi\n\n  if [ \"${UPLOAD_FILE}\" == \"excluded-findings.json\" ]; then\n    MEDIA_TYPE=application/json\n  else\n    MEDIA_TYPE=application/sarif+json\n  fi\n\n  echo \"Selecting auth\"\n  select-oci-auth \"${IMAGE_URL}\" >\"${HOME}/auth.json\"\n  echo \"Attaching to ${IMAGE_URL}\"\n  retry oras attach --no-tty --registry-config \"$HOME/auth.json\" --artifact-type \"${MEDIA_TYPE}\" \"${IMAGE_URL}@${IMAGE_DIGEST}\" \"${UPLOAD_FILE}:${MEDIA_TYPE}\"\ndone\n",
+              "environment": {
+                "container": "upload",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index",
+            "prefetch-dependencies"
+          ],
+          "finishedOn": "2025-09-24T08:00:57Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "49f778479f468e71c2cfef722e96aa813d7ef98bde8a612e1bf1a13cd70849ec"
+              },
+              "entryPoint": "push-dockerfile-oci-ta",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/07d9b6e8-ab48-41c0-8bd8-2e60d44c8c34",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "image-build, appstudio",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-77d4bf950fe16cf3-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "build.appstudio.redhat.com/build_type": "docker",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "push-dockerfile",
+                "tekton.dev/task": "push-dockerfile-oci-ta"
+              }
+            },
+            "parameters": {
+              "ARTIFACT_TYPE": "application/vnd.konflux.dockerfile",
+              "CA_TRUST_CONFIG_MAP_KEY": "ca-bundle.crt",
+              "CA_TRUST_CONFIG_MAP_NAME": "trusted-ca",
+              "CONTEXT": ".",
+              "DOCKERFILE": "Dockerfile",
+              "IMAGE": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "IMAGE_DIGEST": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "SOURCE_ARTIFACT": "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7",
+              "TAG_SUFFIX": ".dockerfile"
+            }
+          },
+          "name": "push-dockerfile",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "push-dockerfile-oci-ta"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:49f778479f468e71c2cfef722e96aa813d7ef98bde8a612e1bf1a13cd70849ec"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGE_REF",
+              "type": "string",
+              "value": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:d7f92ddf6daa3336081b2fe28e42be720148134e908f306f801b7f169dc6f7ac"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": [
+                "use",
+                "oci:quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0@sha256:74adf010f5f30581f72f8e90276a678d42aaf86c9278b1362857650a46f529d7=/var/workdir/source"
+              ],
+              "entryPoint": "",
+              "environment": {
+                "container": "use-trusted-artifact",
+                "image": "oci://quay.io/konflux-ci/build-trusted-artifacts@sha256:1abf94de338e54dd17a0fb84b6d042d1790ede6d1adf235995db5dc1011886f8"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "set -eu\nset -o pipefail\n\nSOURCE_CODE_DIR=source\n\necho \"[$(date --utc -Ins)] Validate context path\"\n\nif [ -z \"$CONTEXT\" ]; then\n  echo \"WARNING: CONTEXT is empty. Defaulting to '.' (the source directory).\" >&2\n  CONTEXT=\".\"\nfi\n\nsource_dir_path=$(realpath \"$SOURCE_CODE_DIR\")\ncontext_dir_path=$(realpath \"$SOURCE_CODE_DIR/$CONTEXT\")\n\ncase \"$context_dir_path\" in\n\"$source_dir_path\" | \"$source_dir_path/\"*)\n  # path is valid, do nothing\n  ;;\n*)\n  echo \"ERROR: The CONTEXT parameter ('$CONTEXT') is invalid because it escapes the source directory.\" >&2\n  echo \"Source path: $source_dir_path\" >&2\n  echo \"Resolved path: $context_dir_path\" >&2\n  exit 1\n  ;;\nesac\n\n# Same discovery logic used in buildah task\nif [ -e \"$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE\"\nelif [ -e \"$SOURCE_CODE_DIR/$DOCKERFILE\" ]; then\n  dockerfile_path=\"$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE\"\nelif echo \"$DOCKERFILE\" | grep -q \"^https\\?://\"; then\n  echo \"Fetch Dockerfile from $DOCKERFILE\"\n  dockerfile_path=$(mktemp --suffix=-dockerfile)\n  http_code=$(curl -s -L -w \"%{http_code}\" --output \"$dockerfile_path\" \"$DOCKERFILE\")\n  if [ $http_code != 200 ]; then\n    echo \"No Dockerfile is fetched. Server responds $http_code\"\n    exit 1\n  fi\nelse\n  echo \"Cannot find Dockerfile $DOCKERFILE\"\n  exit 1\nfi\n\necho \"Selecting auth for $IMAGE\"\nauth_json=$(mktemp)\nselect-oci-auth $IMAGE >\"$auth_json\"\n\ndockerfile_image=${IMAGE%:*}:${IMAGE_DIGEST/:/-}${TAG_SUFFIX}\n\ndockerfile_for_upload_path=/tmp/Dockerfile\ncp \"$dockerfile_path\" \"$dockerfile_for_upload_path\"\ncd \"$(dirname $dockerfile_for_upload_path)\"\necho \"Pushing Dockerfile to registry\"\nif ! retry oras push --no-tty \\\n  --format json \\\n  --registry-config \"$auth_json\" \\\n  --artifact-type \"$ARTIFACT_TYPE\" \\\n  \"$dockerfile_image\" \"$(basename $dockerfile_for_upload_path)\" |\n  yq '.reference' | tr -d '\\r\\n' >\"$IMAGE_REF_RESULT\"; then\n  echo \"Failed to push Dockerfile to registry\"\n  exit 1\nfi\n",
+              "environment": {
+                "container": "push",
+                "image": "oci://quay.io/konflux-ci/oras@sha256:4542f5a2a046ca36653749a8985e46744a5d2d36ee10ca14409be718ce15129e"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:01:18Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "c943625383f1cb95f9fd99506d13a5a12b9c91e7796ea14e228093f9d4995d10"
+              },
+              "entryPoint": "rpms-signature-scan",
+              "uri": "quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/childReadyForDeletion": "true",
+                "results.tekton.dev/record": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa/records/a70e1eb1-67ea-4b87-ab75-b437f521e5fc",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "results.tekton.dev/result": "osci-rhel-containers-tenant/results/0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "results.tekton.dev/stored": "true",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-e3aff00977c019a0-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "tasks",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "rpms-signature-scan",
+                "tekton.dev/task": "rpms-signature-scan"
+              }
+            },
+            "parameters": {
+              "ca-trust-config-map-key": "ca-bundle.crt",
+              "ca-trust-config-map-name": "trusted-ca",
+              "image-digest": "sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740",
+              "image-url": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "workdir": "/tmp"
+            }
+          },
+          "name": "rpms-signature-scan",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "rpms-signature-scan"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:c943625383f1cb95f9fd99506d13a5a12b9c91e7796ea14e228093f9d4995d10"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "results": [
+            {
+              "name": "IMAGES_PROCESSED",
+              "type": "string",
+              "value": "{\"image\": {\"pullspec\": \"quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125\", \"digests\": [\"sha256:fe035b823f9a17b48ab390512f9dfeacf4bfde22e97ae9be0dcbf522f683f960\", \"sha256:94534d60fbd960d2a2818fcac094bd4de7d2a4914721f12bafad5e4acef63b9c\", \"sha256:a2fde47af09006ae2b784881130fb866d92a2037c45059a5c9e014ae6c4ec9c5\", \"sha256:b84a60c3256a1eec24956f8a875136f6f51d6ad5e24db7194396188da0e2d80e\", \"sha256:e2e6d908fbb30dd84ce0bcdf275130a72576bffcbf544d0d9813661870af8740\"]}}\n"
+            },
+            {
+              "name": "RPMS_DATA",
+              "type": "string",
+              "value": "{\"keys\": {\"unsigned\": 0}}\n"
+            },
+            {
+              "name": "TEST_OUTPUT",
+              "type": "string",
+              "value": "{\"result\":\"SUCCESS\",\"timestamp\":\"2025-09-24T08:01:17+00:00\",\"note\":\"Task rpms-signature-scan completed successfully\",\"namespace\":\"default\",\"successes\":0,\"failures\":0,\"warnings\":0}\n"
+            }
+          ],
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:00:49Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -ex\nset -o pipefail\n\nrpm_verifier \\\n  --image-url \"${IMAGE_URL}\" \\\n  --image-digest \"${IMAGE_DIGEST}\" \\\n  --workdir \"${WORKDIR}\" \\\n",
+              "environment": {
+                "container": "rpms-signature-scan",
+                "image": "oci://quay.io/konflux-ci/tools@sha256:91cbef77d25c0dbda07e55d46198d72dfde6b14ae47ae06008fc989901fbf19f"
+              }
+            },
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\nset -ex\n\nsource /utils.sh\nstatus=$(cat \"${WORKDIR}\"/status)\nrpms_data=$(cat \"${WORKDIR}\"/results)\nimages_processed=$(cat \"${WORKDIR}\"/images_processed)\nif [ \"$status\" == \"ERROR\" ]; then\n  note=\"Task rpms-signature-scan failed to scan images. Refer to Tekton task output for details\"\nelse\n  note=\"Task rpms-signature-scan completed successfully\"\nfi\n\nTEST_OUTPUT=$(make_result_json -r \"$status\" -t \"$note\")\necho \"${TEST_OUTPUT}\" | tee \"/tekton/results/TEST_OUTPUT\"\necho \"${rpms_data}\" | tee \"/tekton/results/RPMS_DATA\"\necho \"${images_processed}\" | tee \"/tekton/results/IMAGES_PROCESSED\"\n",
+              "environment": {
+                "container": "output-results",
+                "image": "oci://quay.io/konflux-ci/konflux-test@sha256:42ffa0248c10ffa4ba1d5e606d1ad4265dc4fd52c4988ce63be4929d31df7504"
+              }
+            }
+          ]
+        },
+        {
+          "after": [
+            "build-image-index"
+          ],
+          "finishedOn": "2025-09-24T08:09:49Z",
+          "invocation": {
+            "configSource": {
+              "digest": {
+                "sha256": "beb0616db051952b4b861dd8c3e00fa1c0eccbd926feddf71194d3bb3ace9ce7"
+              },
+              "entryPoint": "show-sbom",
+              "uri": "quay.io/konflux-ci/tekton-catalog/task-show-sbom"
+            },
+            "environment": {
+              "annotations": {
+                "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+                "pipeline.tekton.dev/release": "43c0bb99fa768ff711ad92445c43179b93232877",
+                "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+                "pipelinesascode.tekton.dev/git-provider": "gitlab",
+                "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+                "pipelinesascode.tekton.dev/max-keep-runs": "3",
+                "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+                "pipelinesascode.tekton.dev/sender": "jpopelka",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+                "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+                "pipelinesascode.tekton.dev/source-project-id": "57944679",
+                "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/target-project-id": "57944679",
+                "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}",
+                "tekton.dev/pipelines.minVersion": "0.12.1",
+                "tekton.dev/tags": "konflux",
+                "tekton.dev/taskrunSpanContext": "{\"traceparent\":\"00-60fe64a850be2bb7cd0824ad93a19416-7e6003ae3a272709-01\"}"
+              },
+              "labels": {
+                "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+                "app.kubernetes.io/version": "v0.37.0",
+                "appstudio.openshift.io/application": "rhel-10-0",
+                "appstudio.openshift.io/component": "ubi10-10-0",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "pipelines.appstudio.openshift.io/type": "build",
+                "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+                "pipelinesascode.tekton.dev/event-type": "push",
+                "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+                "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+                "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+                "pipelinesascode.tekton.dev/state": "queued",
+                "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+                "pipelinesascode.tekton.dev/url-repository": "ubi10",
+                "tekton.dev/memberOf": "finally",
+                "tekton.dev/pipeline": "build-pipeline",
+                "tekton.dev/pipelineRun": "ubi10-10-0-on-push-t2x6l",
+                "tekton.dev/pipelineRunUID": "0037e0fb-98fe-4625-b281-c736fcc96efa",
+                "tekton.dev/pipelineTask": "show-sbom",
+                "tekton.dev/task": "show-sbom"
+              }
+            },
+            "parameters": {
+              "CA_TRUST_CONFIG_MAP_KEY": "ca-bundle.crt",
+              "CA_TRUST_CONFIG_MAP_NAME": "trusted-ca",
+              "IMAGE_URL": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+              "PLATFORM": "linux/amd64"
+            }
+          },
+          "name": "show-sbom",
+          "ref": {
+            "params": [
+              {
+                "name": "name",
+                "value": "show-sbom"
+              },
+              {
+                "name": "bundle",
+                "value": "quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:beb0616db051952b4b861dd8c3e00fa1c0eccbd926feddf71194d3bb3ace9ce7"
+              },
+              {
+                "name": "kind",
+                "value": "task"
+              }
+            ],
+            "resolver": "bundles"
+          },
+          "serviceAccountName": "build-pipeline-ubi10-10-0",
+          "startedOn": "2025-09-24T08:09:42Z",
+          "status": "Succeeded",
+          "steps": [
+            {
+              "annotations": null,
+              "arguments": null,
+              "entryPoint": "#!/bin/bash\n\ndownload_sbom_with_retry() {\n  local extra_args=(\"$@\")\n\n  # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec\n  mkdir -p /tmp/auth\n  if ! select-oci-auth \"$IMAGE_URL\" 2>/tmp/stderr >/tmp/auth/config.json; then\n    # Print stderr only in case of failure. This task is supposed to output *only* the SBOM on success.\n    cat /tmp/stderr\n    exit 1\n  fi\n\n  export DOCKER_CONFIG=/tmp/auth\n  if ! retry cosign download sbom \"${extra_args[@]}\" \"$IMAGE_URL\" 2>>err\n  then\n    echo \"Failed to get SBOM\" >&2\n    cat err >&2\n  fi\n}\n\nRAW_OUTPUT=$(skopeo inspect --no-tags --raw docker://${IMAGE_URL})\nif [ \"$(jq 'has(\"manifests\")' <<< \"$RAW_OUTPUT\")\" == \"true\" ] ; then\n  # Multi arch\n  ARCHES=$(jq -r '.manifests[].platform.architecture' <<< $RAW_OUTPUT)\nelse\n  ARCHES=\"\"\nfi\n\nif [ -z \"${ARCHES}\" ] ; then\n  # single arch image\n  download_sbom_with_retry\nelse\n  download_sbom_with_retry --platform=\"$PLATFORM\"\nfi\n",
+              "environment": {
+                "container": "show-sbom",
+                "image": "oci://quay.io/konflux-ci/appstudio-utils@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "buildType": "tekton.dev/v1beta1/PipelineRun",
+    "builder": {
+      "id": "https://tekton.dev/chains/v2"
+    },
+    "invocation": {
+      "configSource": {
+        "digest": {
+          "sha1": "13e6d4636ec14eb5755123fe38675d989d1747a1"
+        },
+        "entryPoint": ".tekton/build-pipeline.yaml",
+        "uri": "git+https://gitlab.com/redhat/rhel/containers/tekton-pipelines.git"
+      },
+      "environment": {
+        "annotations": {
+          "build.appstudio.openshift.io/repo": "https://gitlab.com/redhat/rhel/containers/ubi10/-/tree/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+          "build.appstudio.redhat.com/commit_sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+          "build.appstudio.redhat.com/target_branch": "rhel-10.0",
+          "pipelinesascode.tekton.dev/branch": "rhel-10.0",
+          "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+          "pipelinesascode.tekton.dev/controller-info": "{\"name\":\"default\",\"configmap\":\"pipelines-as-code\",\"secret\":\"pipelines-as-code-secret\", \"gRepo\": \"pipelines-as-code\"}",
+          "pipelinesascode.tekton.dev/event-type": "push",
+          "pipelinesascode.tekton.dev/git-auth-secret": "pac-gitauth-zferfw",
+          "pipelinesascode.tekton.dev/git-provider": "gitlab",
+          "pipelinesascode.tekton.dev/log-url": "https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/osci-rhel-containers-tenant/pipelinerun/ubi10-10-0-on-push-t2x6l",
+          "pipelinesascode.tekton.dev/max-keep-runs": "3",
+          "pipelinesascode.tekton.dev/on-cel-expression": "event == \"push\" && target_branch == \"rhel-10.0\" && files.all.exists(x, !x.startsWith(\".tekton/\"))\n",
+          "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+          "pipelinesascode.tekton.dev/repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+          "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+          "pipelinesascode.tekton.dev/scm-reporting-plr-started": "true",
+          "pipelinesascode.tekton.dev/sender": "jpopelka",
+          "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+          "pipelinesascode.tekton.dev/sha-title": "chore(deps): refresh rpm lockfiles",
+          "pipelinesascode.tekton.dev/sha-url": "https://gitlab.com/redhat/rhel/containers/ubi10/-/commit/15e5733dc128d8178e29f49c1c417ff41c5d7125",
+          "pipelinesascode.tekton.dev/source-branch": "refs/heads/rhel-10.0",
+          "pipelinesascode.tekton.dev/source-project-id": "57944679",
+          "pipelinesascode.tekton.dev/source-repo-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+          "pipelinesascode.tekton.dev/state": "queued",
+          "pipelinesascode.tekton.dev/target-project-id": "57944679",
+          "pipelinesascode.tekton.dev/url-org": "redhat/rhel/containers",
+          "pipelinesascode.tekton.dev/url-repository": "ubi10",
+          "results.tekton.dev/recordSummaryAnnotations": "{\"repo\":\"ubi10\",\"commit\":\"15e5733dc128d8178e29f49c1c417ff41c5d7125\",\"eventType\":\"push\"}"
+        },
+        "labels": {
+          "app.kubernetes.io/managed-by": "pipelinesascode.tekton.dev",
+          "app.kubernetes.io/version": "v0.37.0",
+          "appstudio.openshift.io/application": "rhel-10-0",
+          "appstudio.openshift.io/component": "ubi10-10-0",
+          "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+          "kueue.x-k8s.io/queue-name": "pipelines-queue",
+          "pipelines.appstudio.openshift.io/type": "build",
+          "pipelinesascode.tekton.dev/cancel-in-progress": "false",
+          "pipelinesascode.tekton.dev/event-type": "push",
+          "pipelinesascode.tekton.dev/original-prname": "ubi10-10-0-on-push",
+          "pipelinesascode.tekton.dev/repository": "ubi10-10-0-beta",
+          "pipelinesascode.tekton.dev/sha": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+          "pipelinesascode.tekton.dev/state": "queued",
+          "pipelinesascode.tekton.dev/url-org": "redhat-rhel-containers",
+          "pipelinesascode.tekton.dev/url-repository": "ubi10",
+          "tekton.dev/pipeline": "build-pipeline"
+        }
+      },
+      "parameters": {
+        "build-args": [ ],
+        "build-args-file": "",
+        "build-image-index": "true",
+        "build-platforms": [
+          "linux/x86_64",
+          "linux/arm64",
+          "linux/s390x",
+          "linux/ppc64le"
+        ],
+        "build-source-image": "true",
+        "dockerfile": "Dockerfile",
+        "git-url": "https://gitlab.com/redhat/rhel/containers/ubi10",
+        "hermetic": "true",
+        "image-expires-after": "",
+        "output-image": "quay.io/redhat-user-workloads/osci-rhel-containers-tenant/rhel-10-0/ubi10-10-0:15e5733dc128d8178e29f49c1c417ff41c5d7125",
+        "path-context": ".",
+        "prefetch-input": "[{\"type\": \"rpm\"}]",
+        "prefetch-log-level": "debug",
+        "rebuild": "false",
+        "revision": "15e5733dc128d8178e29f49c1c417ff41c5d7125",
+        "skip-checks": "false"
+      }
+    },
+    "materials": [
+      {
+        "digest": {
+          "sha1": "13e6d4636ec14eb5755123fe38675d989d1747a1"
+        },
+        "uri": "git+https://gitlab.com/redhat/rhel/containers/tekton-pipelines.git"
+      },
+      {
+        "digest": {
+          "sha256": "a65a413f8a2864389a09dc750690d97afbcdc5c70821e0f85e99e8adba7954e0"
+        },
+        "uri": "oci://registry.access.redhat.com/ubi9/skopeo"
+      },
+      {
+        "digest": {
+          "sha256": "ec962d0be18f36ca7d331c99bf243800f569fc0a2ea6f8c8c3d3a574b71c44dc"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-init"
+      },
+      {
+        "digest": {
+          "sha256": "0e92b8a655d7b2eeba6442bbe008c92ad7f21ea23d8ad76cd95d45353338c1e0"
+        },
+        "uri": "oci://quay.io/konflux-ci/git-clone"
+      },
+      {
+        "digest": {
+          "sha256": "1abf94de338e54dd17a0fb84b6d042d1790ede6d1adf235995db5dc1011886f8"
+        },
+        "uri": "oci://quay.io/konflux-ci/build-trusted-artifacts"
+      },
+      {
+        "digest": {
+          "sha256": "3f1b468066b301083d8550e036f5a654fcb064810bd29eb06fec6d8ad3e35b9c"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8"
+        },
+        "uri": "oci://registry.access.redhat.com/ubi9/ubi-minimal"
+      },
+      {
+        "digest": {
+          "sha256": "98641d6162ee305d09927a87c7c8245a77bffb0061aef6ed18f14c1348a77d07"
+        },
+        "uri": "oci://quay.io/konflux-ci/build-trusted-artifacts"
+      },
+      {
+        "digest": {
+          "sha256": "7ef2e2f76ca36bdc7eb9203df31f3bce546d1267b969d9bd2691094b88610dbb"
+        },
+        "uri": "oci://quay.io/konflux-ci/yq"
+      },
+      {
+        "digest": {
+          "sha256": "bd7d43d80dde2fdd82fb9c9952aba9f830b052bcb1e5f3b54d613555b3a2eda7"
+        },
+        "uri": "oci://quay.io/konflux-ci/hermeto"
+      },
+      {
+        "digest": {
+          "sha256": "098322d6b789824f716f2d9caca1862d4afdc083ebaaee61aadd22a8c179480a"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "875f69f9e2172d627bd01aaf7a0d49f67ffebc07fc148ae0d50865e48bd401b9"
+        },
+        "uri": "oci://quay.io/konflux-ci/yq"
+      },
+      {
+        "digest": {
+          "sha256": "9d5bc8e93a458102ea119c6828a654ae5ee5e9d0aa0ab462f01d2ebac268e737"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-generate-labels"
+      },
+      {
+        "digest": {
+          "sha256": "1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458"
+        },
+        "uri": "oci://quay.io/konflux-ci/buildah-task"
+      },
+      {
+        "digest": {
+          "sha256": "dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28"
+        },
+        "uri": "oci://registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9"
+      },
+      {
+        "digest": {
+          "sha256": "41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc"
+        },
+        "uri": "oci://quay.io/konflux-ci/mobster"
+      },
+      {
+        "digest": {
+          "sha256": "90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c"
+        },
+        "uri": "oci://quay.io/konflux-ci/appstudio-utils"
+      },
+      {
+        "digest": {
+          "sha256": "17a0b093c9e9d21e9e374c60a88eb293a0fa57e4e2b67baf20ccac9735aa20ff"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "8e5dfb2fac011148f8715bbe0b99415f88297683d269eae0dfcad52562195d45"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-build-image-index"
+      },
+      {
+        "digest": {
+          "sha256": "db0a53425f0e43c32450deab48380eb1350c47424c3e4ae61555547f009604ef"
+        },
+        "uri": "oci://quay.io/konflux-ci/source-container-build"
+      },
+      {
+        "digest": {
+          "sha256": "b0d6cb28a23f20db4f5cf78ed78ae3a91b9a5adfe989696ed0bbc63840a485b6"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "42ffa0248c10ffa4ba1d5e606d1ad4265dc4fd52c4988ce63be4929d31df7504"
+        },
+        "uri": "oci://quay.io/konflux-ci/konflux-test"
+      },
+      {
+        "digest": {
+          "sha256": "2c32152a55f6bfba67b41be456da46b6e109bb3e348e25220eed4eed149958c5"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check"
+      },
+      {
+        "digest": {
+          "sha256": "4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9"
+        },
+        "uri": "oci://quay.io/konflux-ci/konflux-test"
+      },
+      {
+        "digest": {
+          "sha256": "6386cbb69b5ddf94168f9397a8795365f4d7500103e15ec8f6bd256afd75a33b"
+        },
+        "uri": "oci://quay.io/konflux-ci/clair-in-ci"
+      },
+      {
+        "digest": {
+          "sha256": "1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b"
+        },
+        "uri": "oci://quay.io/konflux-ci/oras"
+      },
+      {
+        "digest": {
+          "sha256": "a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-clair-scan"
+      },
+      {
+        "digest": {
+          "sha256": "4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd"
+        },
+        "uri": "oci://quay.io/konflux-ci/build-trusted-artifacts"
+      },
+      {
+        "digest": {
+          "sha256": "783f5de1b4def2fb3fad20b914f4b3afee46ffb8f652114946e321ef3fa86449"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "1a3eb068f26dae6f8fc6991d72f38cbf553e06aef38b36ac23428a990be8f282"
+        },
+        "uri": "oci://quay.io/konflux-ci/clamav-db"
+      },
+      {
+        "digest": {
+          "sha256": "8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd"
+        },
+        "uri": "oci://quay.io/konflux-ci/oras"
+      },
+      {
+        "digest": {
+          "sha256": "b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-clamav-scan"
+      },
+      {
+        "digest": {
+          "sha256": "7e04a34cc9adb5fa0bfe5070d1a60321205f5e6f0cd3fb2e8a33a5ec8508fd29"
+        },
+        "uri": "oci://quay.io/konflux-ci/konflux-test"
+      },
+      {
+        "digest": {
+          "sha256": "bf7bdde00b7212f730c1356672290af6f38d070da2c8a316987b5c32fd49e0b9"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "4542f5a2a046ca36653749a8985e46744a5d2d36ee10ca14409be718ce15129e"
+        },
+        "uri": "oci://quay.io/konflux-ci/oras"
+      },
+      {
+        "digest": {
+          "sha256": "49f778479f468e71c2cfef722e96aa813d7ef98bde8a612e1bf1a13cd70849ec"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta"
+      },
+      {
+        "digest": {
+          "sha256": "91cbef77d25c0dbda07e55d46198d72dfde6b14ae47ae06008fc989901fbf19f"
+        },
+        "uri": "oci://quay.io/konflux-ci/tools"
+      },
+      {
+        "digest": {
+          "sha256": "c943625383f1cb95f9fd99506d13a5a12b9c91e7796ea14e228093f9d4995d10"
+        },
+        "uri": "quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan"
+      },
+      {
+        "digest": {
+          "sha256": "beb0616db051952b4b861dd8c3e00fa1c0eccbd926feddf71194d3bb3ace9ce7"
+        },
+        "uri": "quay.io/konflux-ci/tekton-catalog/task-show-sbom"
+      },
+      {
+        "digest": {
+          "sha1": "15e5733dc128d8178e29f49c1c417ff41c5d7125"
+        },
+        "uri": "git+https://gitlab.com/redhat/rhel/containers/ubi10.git"
+      }
+    ],
+    "metadata": {
+      "buildFinishedOn": "2025-09-24T08:09:49Z",
+      "buildStartedOn": "2025-09-24T07:24:03Z",
+      "completeness": {
+        "environment": false,
+        "materials": false,
+        "parameters": false
+      },
+      "reproducible": false
+    }
+  }
+}

--- a/tests/data/integration/parsed_dockerfile.json
+++ b/tests/data/integration/parsed_dockerfile.json
@@ -1,0 +1,42 @@
+{
+  "MetaArgs": null,
+  "Stages": [
+    {
+      "Name": "",
+      "OrigCmd": "from",
+      "BaseName": "registry.redhat.io/ubi10:latest",
+      "Platform": "",
+      "Comment": "",
+      "SourceCode": "from registry.redhat.io/ubi10:latest",
+      "Location": [
+        {
+          "Start": {
+            "Line": 1,
+            "Character": 0
+          },
+          "End": {
+            "Line": 1,
+            "Character": 0
+          }
+        }
+      ],
+      "From": {
+        "Image": "registry.redhat.io/ubi10:latest"
+      },
+      "Commands": [
+        {
+          "CmdLine": [
+            "touch a.txt"
+          ],
+          "Files": null,
+          "FlagsUsed": [],
+          "Mounts": [],
+          "Name": "RUN",
+          "NetworkMode": "default",
+          "PrependShell": true,
+          "Security": "sandbox"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/img_utils.py
+++ b/tests/integration/img_utils.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+from mobster.image import Image, IndexImage
+from mobster.utils import run_async_subprocess
+from tests.integration.oci_client import ReferrersTagOCIClient
+
+TESTDATA_PATH = Path(__file__).parent.parent / "data"
+
+
+async def create_child_image(
+    oci_client: ReferrersTagOCIClient, repository: str, tag: str
+) -> Image:
+    """
+    Create a sample child image in the OCI registry.
+
+    Args:
+        oci_client (ReferrersTagOCIClient): A client for interacting with the OCI
+        registry.
+        repository (str): A name of the repository where the image will be created.
+        tag (str): A tag for the image.
+
+    Returns:
+        Image: A created image object.
+    """
+    return await oci_client.create_image(
+        repository,
+        f"{tag}-child",
+    )
+
+
+async def create_index_image(
+    oci_client: ReferrersTagOCIClient, repository: str, tag: str, child_image: Image
+) -> IndexImage:
+    """
+    Create an OCI image index that contains the child image.
+
+    Args:
+        oci_client (ReferrersTagOCIClient): A client for interacting with the OCI
+        registry.
+        repository (str): A name of the repository where the index image will be
+        created.
+        tag (str): A tag for the index image.
+        child_image (Image): A child image to include in the index.
+
+    Returns:
+        Image: A created index image object.
+    """
+    return await oci_client.create_image_index(
+        repository,
+        f"{tag}-parent",
+        images=[child_image],
+    )
+
+
+async def generate_child_image_sbom(child_image: Image, output_dir: Path) -> Path:
+    """
+    Generate an SBOM for a child image using the `mobster` command-line tool.
+
+    Args:
+        child_image (Image): A child image for which the SBOM will be generated.
+        output_dir (Path): A directory where the SBOM will be saved.
+
+    Returns:
+        Path: A path to the generated SBOM file.
+    """
+    output_file = output_dir / "oci-image.spdx.json"
+    code, _, stderr = await run_async_subprocess(
+        [
+            "mobster",
+            "generate",
+            "--output",
+            str(output_file),
+            "oci-image",
+            "--from-syft",
+            str(TESTDATA_PATH / "integration" / "image.syft.spdx.json"),
+            "--image-digest",
+            child_image.digest,
+            "--image-pullspec",
+            f"{child_image.repository}:{child_image.tag}",
+            "--parsed-dockerfile-path",
+            str(TESTDATA_PATH / "integration" / "parsed_dockerfile.json"),
+            "--base-image-digest-file",
+            str(TESTDATA_PATH / "integration" / "base_image_digest.txt"),
+        ],
+    )
+    if code != 0:
+        raise RuntimeError(
+            f"Failed to generate SBOM for {child_image.repository}:{child_image.tag}. "
+            f"Error: {stderr.decode()}"
+        )
+    return output_file
+
+
+async def generate_index_image_sbom(index_image: IndexImage, output_dir: Path) -> Path:
+    """
+    Generate an SBOM for an OCI image index using the `mobster` command-line tool.
+
+    Args:
+        index_image (Image): An index image for which the SBOM will be generated.
+        output_dir (Path): A directory where the SBOM will be saved.
+
+    Returns:
+        Path: A path to the generated SBOM file.
+    """
+    index_manifest_path = output_dir / "index-manifest.json"
+    with open(index_manifest_path, "w", encoding="utf-8") as file:
+        file.write(index_image.manifest or "")
+
+    output_file = output_dir / "oci-index.spdx.json"
+    code, _, stderr = await run_async_subprocess(
+        [
+            "mobster",
+            "generate",
+            "--output",
+            str(output_file),
+            "oci-index",
+            "--index-image-digest",
+            index_image.digest,
+            "--index-image-pullspec",
+            f"{index_image.repository}:{index_image.tag}",
+            "--index-manifest-path",
+            str(index_manifest_path),
+        ],
+    )
+    if code != 0:
+        raise RuntimeError(
+            f"Failed to generate SBOM for {index_image.repository}:{index_image.tag}. "
+            f"Error: {stderr.decode()}"
+        )
+    return output_file

--- a/tests/integration/oci_client.py
+++ b/tests/integration/oci_client.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal
 
 import httpx
@@ -232,7 +233,7 @@ class ReferrersTagOCIClient:
         # with spec
         config_digest = await self._push_blob(image.name, b"")
         await self._push_manifest(image.name, derived_tag, config_digest, layers)
-        return image.repository + ":" + derived_tag + "@" + sbom_blob_digest
+        return f"{image.repository}@{sbom_blob_digest}"
 
     async def _push_blob(self, name: str, blob: bytes) -> str:
         """
@@ -312,3 +313,70 @@ class ReferrersTagOCIClient:
             resp.raise_for_status()
             digest = resp.headers["location"].split("/")[-1]
             return digest
+
+    async def sign_image(self, image: Image, private_key: Path) -> None:
+        """
+        Sign an image in the registry using cosign.
+
+        Args:
+            image: The image to sign.
+            private_key: The path to the private key file.
+        """
+        image_pullspec = f"{image.repository}@{image.digest}"
+        cmd = [
+            "cosign",
+            "sign",
+            "--key",
+            str(private_key),
+            "--tlog-upload=false",
+            image_pullspec,
+        ]
+        code, stdout, stderr = await run_async_subprocess(
+            cmd,
+            env={"COSIGN_PASSWORD": ""},
+        )
+        if code != 0:
+            raise RuntimeError(
+                f"Failed to sign image {image_pullspec} in registry.\n"
+                f"CMD: {' '.join(cmd)}\n"
+                f"Error: {stderr.decode()}"
+            )
+        return None
+
+    async def push_attestation(
+        self, image: Image, attestation_path: Path, type: str, private_key: Path
+    ) -> None:
+        """
+        Push an attestation to the registry using cosign and associate it with
+        the specified image.
+
+        Args:
+            image: The image to attach the attestation to.
+            attestation_path: The path to the attestation file.
+            type: Attestation type (e.g., slsaprovenance02).
+            private_key: The path to the private key file.
+        """
+        cmd = [
+            "cosign",
+            "attest",
+            "--predicate",
+            str(attestation_path),
+            "--type",
+            type,
+            "--key",
+            str(private_key),
+            "--tlog-upload=false",
+            f"{image.repository}@{image.digest}",
+        ]
+        code, _, stderr = await run_async_subprocess(
+            cmd,
+            env={"COSIGN_PASSWORD": ""},
+        )
+        if code != 0:
+            raise RuntimeError(
+                "Failed to push attestation for image "
+                f"{image.repository}@{image.digest}.\n"
+                f"CMD: {' '.join(cmd)}\n"
+                f"Error: {stderr.decode()}"
+            )
+        return None

--- a/tests/integration/test_conforma.py
+++ b/tests/integration/test_conforma.py
@@ -1,0 +1,281 @@
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from mobster.image import Image
+from mobster.utils import run_async_subprocess
+from tests.integration import img_utils
+from tests.integration.oci_client import ReferrersTagOCIClient
+
+TESTDATA_PATH = Path(__file__).parent.parent / "data"
+
+
+async def generate_key_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """
+    Generate a public/private key pair for signing attestation.
+
+    Args:
+        tmp_path (Path): A temporary directory path to store the keys.
+
+    Returns:
+        tuple[Path, Path]: Paths to the private and public keys.
+
+    """
+
+    code, _, stderr = await run_async_subprocess(
+        [
+            "cosign",
+            "generate-key-pair",
+        ],
+        env={"COSIGN_PASSWORD": ""},
+        cwd=tmp_path,
+    )
+    if code != 0:
+        raise RuntimeError(
+            f"Failed to generate keypar using cosign.Error: {stderr.decode()}"
+        )
+    return tmp_path / "cosign.key", tmp_path / "cosign.pub"
+
+
+def update_index_image_step(
+    task: dict[str, Any], index_img: Image, child_img: Image, index_sbom_ref: str
+) -> None:
+    """
+    Update attestation result of index image build step with actual image details.
+
+    Args:
+        task (dict[str, Any]): A index image build task from attestation data.
+        index_img (Image): A created index image object.
+        child_img (Image): A created child image object.
+        index_sbom_ref (str): A reference of the index image SBOM.
+    """
+    for result in task.get("results", []):
+        if result.get("name") == "IMAGES":
+            result["value"] = f"{child_img.repository}@{child_img.digest}"
+        if result.get("name") == "IMAGE_DIGEST":
+            result["value"] = index_img.digest
+        if result.get("name") == "IMAGE_REF":
+            result["value"] = f"{index_img.repository}@{index_img.digest}"
+        if result.get("name") == "IMAGE_URL":
+            result["value"] = f"{index_img.repository}:{index_img.tag}"
+        if result.get("name") == "SBOM_BLOB_URL":
+            result["value"] = index_sbom_ref
+
+
+def update_child_image_step(
+    task: dict[str, Any], child_img: Image, child_sbom_ref: str
+) -> None:
+    """
+    Update attestation result of child image build step with actual image details.
+
+    Args:
+        task (dict[str, Any]): A child image build task from attestation data.
+        child_img (Image): A created child image object.
+        child_sbom_digest (str): A reference of the child image SBOM.
+    """
+    for result in task.get("results", []):
+        if result.get("name") == "IMAGE_DIGEST":
+            result["value"] = child_img.digest
+        if result.get("name") == "IMAGE_REF":
+            result["value"] = f"{child_img.repository}@{child_img.digest}"
+        if result.get("name") == "IMAGE_URL":
+            result["value"] = f"{child_img.repository}:{child_img.tag}"
+        if result.get("name") == "SBOM_BLOB_URL":
+            result["value"] = child_sbom_ref
+
+
+def update_attestation_with_image_details(
+    attestation_data: dict[str, Any],
+    index_img: Image,
+    child_img: Image,
+    index_sbom_ref: str,
+    child_sbom_ref: str,
+) -> None:
+    """
+    Inject image details into attestation data to match with pushed images.
+
+    Args:
+        attestation_data (dict[str, Any]): Attestation data template.
+        index_img (Image): Index image to inject details for.
+        child_img (Image): Child image to inject details for.
+        index_sbom_ref (str): Index SBOM reference
+        child_sbom_ref (str): Child SBOM reference.
+
+    """
+
+    tasks = attestation_data.get("buildConfig", {}).get("tasks", [])
+    for task in tasks:
+        if task.get("name") == "build-image-index":
+            update_index_image_step(task, index_img, child_img, index_sbom_ref)
+        if task.get("name") == "build-images":
+            update_child_image_step(task, child_img, child_sbom_ref)
+
+
+async def create_image_attestation(
+    oci_client: ReferrersTagOCIClient,
+    index_img: Image,
+    child_img: Image,
+    index_sbom_ref: str,
+    child_sbom_ref: str,
+    private_key_path: Path,
+    tmp_path: Path,
+) -> None:
+    """
+    Create attestation with data matching the pushed images and upload it to the
+    OCI registry as signed attestation associated with both images.
+
+    Args:
+        oci_client (ReferrersTagOCIClient): Registry client to use for uploading
+            the attestation.
+        index_img (Image): Index image to associate the attestation with.
+        child_img (Image): Child image to associate the attestation with.
+        index_sbom_ref (str): Index SBOM reference.
+        child_sbom_ref (str): Child SBOM reference.
+        private_key_path (Path): A path to the private key for signing the
+            attestation.
+        tmp_path (Path): A temporary directory path to store the attestation file.
+    """
+    attestatuon_template_path = TESTDATA_PATH / "integration" / "img_attestation.json"
+    with open(attestatuon_template_path, encoding="utf-8") as attestation_file:
+        attestation_data = json.load(attestation_file)["predicate"]
+
+    update_attestation_with_image_details(
+        attestation_data, index_img, child_img, index_sbom_ref, child_sbom_ref
+    )
+
+    # Write the updated attestation to a temporary file
+    attestatuon_path = tmp_path / "img_attestation.json"
+    with open(attestatuon_path, "w", encoding="utf-8") as attestation_file:
+        json.dump(attestation_data, attestation_file, indent=2)
+
+    await oci_client.push_attestation(
+        child_img, attestatuon_path, "slsaprovenance02", private_key_path
+    )
+    await oci_client.push_attestation(
+        index_img, attestatuon_path, "slsaprovenance02", private_key_path
+    )
+
+
+def create_policy_file(policy_dir_path: Path) -> Path:
+    """
+    Create a Conforma policy file in the specified directory with SBOM related
+    checks enabled.
+    Args:
+        policy_dir_path (Path): A directory where the policy file will be created.
+
+    Returns:
+        Path: A path to the created policy file.
+    """
+    policy = {
+        "sources": [
+            {
+                "policy": ["github.com/conforma/policy//policy"],
+                "config": {
+                    # These are the checks that will be run by Conforma
+                    # and are relevant for SBOM validation.
+                    "include": [
+                        "sbom",
+                        "sbom_spdx",
+                        "sbom_cyclonedx",
+                        "rpm_repos",
+                        "base_image_registries",
+                    ]
+                },
+                "data": ["git::https://github.com/conforma/policy//example/data"],
+            }
+        ]
+    }
+    policy_path = policy_dir_path / "policy.json"
+    with open(policy_path, "w", encoding="utf-8") as policy_file:
+        yaml.safe_dump(policy, policy_file)
+    return policy_path
+
+
+async def verify_conforma(image: Image, public_key: Path, tmp_path: Path) -> None:
+    """
+    Validate a conforma rules agains a provided image.
+
+    Args:
+        image (Image): An image to validate.
+        public_key (Path): A path to the public key for verifying the attestation.
+        tmp_path (Path): A temporary directory path to store the policy file.
+
+    """
+    policy_file_path = create_policy_file(tmp_path)
+    cmd = [
+        "ec",
+        "validate",
+        "image",
+        "--policy",
+        str(policy_file_path),
+        "--public-key",
+        str(public_key),
+        "--ignore-rekor",
+        "--image",
+        f"{image.repository}@{image.digest}",
+    ]
+    code, stdout, stderr = await run_async_subprocess(cmd)
+    if code != 0:
+        raise RuntimeError(
+            f"Failed to run conforma:\n"
+            f"CMD: {' '.join(cmd)}\n"
+            f"Error: {stderr.decode()}\n"
+            f"Output: {stdout.decode()}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_oci_image_sboms_using_conforma(
+    oci_client: ReferrersTagOCIClient, tmp_path: Path
+) -> None:
+    """
+    Verify that SBOMs generated by Mobster for OCI images can be validated
+    using Conforma and don't trigger any policy violations.
+
+    Args:
+        oci_client (ReferrersTagOCIClient): A registry client to use for pushing
+            and pulling images and associated artifacts.
+        tmp_path (Path): A temporary directory path to store generated files.
+    """
+    tag_prefix = f"{random.randint(100, 9999)}"
+    repository = "test-repo"
+
+    private_key_path, public_key_path = await generate_key_pair(tmp_path)
+
+    child_image = await img_utils.create_child_image(oci_client, repository, tag_prefix)
+    index_image = await img_utils.create_index_image(
+        oci_client,
+        repository,
+        tag_prefix,
+        child_image,
+    )
+
+    await oci_client.sign_image(index_image, private_key_path)
+    await oci_client.sign_image(child_image, private_key_path)
+
+    child_sbom = await img_utils.generate_child_image_sbom(child_image, tmp_path)
+    index_sbom = await img_utils.generate_index_image_sbom(index_image, tmp_path)
+
+    child_sbom_ref = await oci_client.attach_sbom(
+        child_image, "spdx", child_sbom.read_bytes()
+    )
+    index_sbom_ref = await oci_client.attach_sbom(
+        index_image, "spdx", index_sbom.read_bytes()
+    )
+
+    await create_image_attestation(
+        oci_client,
+        index_image,
+        child_image,
+        index_sbom_ref,
+        child_sbom_ref,
+        private_key_path,
+        tmp_path,
+    )
+
+    await verify_conforma(index_image, public_key_path, tmp_path)
+    await verify_conforma(child_image, public_key_path, tmp_path)

--- a/tests/integration/test_reference_integrity.py
+++ b/tests/integration/test_reference_integrity.py
@@ -8,128 +8,10 @@ import pytest
 from mobster.cmd.upload.tpa import TPAClient
 from mobster.image import Image, IndexImage
 from mobster.utils import run_async_subprocess
+from tests.integration import img_utils
 from tests.integration.oci_client import ReferrersTagOCIClient
 
 TESTDATA_PATH = Path(__file__).parent.parent / "data"
-
-
-async def create_child_image(
-    oci_client: ReferrersTagOCIClient, repository: str, tag: str
-) -> Image:
-    """
-    Create a sample child image in the OCI registry.
-
-    Args:
-        oci_client (ReferrersTagOCIClient): A client for interacting with the OCI
-        registry.
-        repository (str): A name of the repository where the image will be created.
-        tag (str): A tag for the image.
-
-    Returns:
-        Image: A created image object.
-    """
-    return await oci_client.create_image(
-        repository,
-        f"{tag}-child",
-    )
-
-
-async def create_index_image(
-    oci_client: ReferrersTagOCIClient, repository: str, tag: str, child_image: Image
-) -> IndexImage:
-    """
-    Create an OCI image index that contains the child image.
-
-    Args:
-        oci_client (ReferrersTagOCIClient): A client for interacting with the OCI
-        registry.
-        repository (str): A name of the repository where the index image will be
-        created.
-        tag (str): A tag for the index image.
-        child_image (Image): A child image to include in the index.
-
-    Returns:
-        Image: A created index image object.
-    """
-    return await oci_client.create_image_index(
-        repository,
-        f"{tag}-parent",
-        images=[child_image],
-    )
-
-
-async def generate_child_image_sbom(child_image: Image, output_dir: Path) -> Path:
-    """
-    Generate an SBOM for a child image using the `mobster` command-line tool.
-
-    Args:
-        child_image (Image): A child image for which the SBOM will be generated.
-        output_dir (Path): A directory where the SBOM will be saved.
-
-    Returns:
-        Path: A path to the generated SBOM file.
-    """
-    output_file = output_dir / "oci-image.spdx.json"
-    code, _, stderr = await run_async_subprocess(
-        [
-            "mobster",
-            "generate",
-            "--output",
-            str(output_file),
-            "oci-image",
-            "--from-syft",
-            str(TESTDATA_PATH / "integration" / "image.syft.spdx.json"),
-            "--image-digest",
-            child_image.digest,
-            "--image-pullspec",
-            f"{child_image.repository}:{child_image.tag}",
-        ],
-    )
-    if code != 0:
-        raise RuntimeError(
-            f"Failed to generate SBOM for {child_image.repository}:{child_image.tag}. "
-            f"Error: {stderr.decode()}"
-        )
-    return output_file
-
-
-async def generate_index_image_sbom(index_image: Image, output_dir: Path) -> Path:
-    """
-    Generate an SBOM for an OCI image index using the `mobster` command-line tool.
-
-    Args:
-        index_image (Image): An index image for which the SBOM will be generated.
-        output_dir (Path): A directory where the SBOM will be saved.
-
-    Returns:
-        Path: A path to the generated SBOM file.
-    """
-    index_manifest_path = output_dir / "index-manifest.json"
-    with open(index_manifest_path, "w", encoding="utf-8") as file:
-        file.write(index_image.manifest or "")
-
-    output_file = output_dir / "oci-index.spdx.json"
-    code, _, stderr = await run_async_subprocess(
-        [
-            "mobster",
-            "generate",
-            "--output",
-            str(output_file),
-            "oci-index",
-            "--index-image-digest",
-            index_image.digest,
-            "--index-image-pullspec",
-            f"{index_image.repository}:{index_image.tag}",
-            "--index-manifest-path",
-            str(index_manifest_path),
-        ],
-    )
-    if code != 0:
-        raise RuntimeError(
-            f"Failed to generate SBOM for {index_image.repository}:{index_image.tag}. "
-            f"Error: {stderr.decode()}"
-        )
-    return output_file
 
 
 def _get_document_describes_package(document: dict[str, Any]) -> Any:
@@ -388,15 +270,15 @@ async def test_consistent_reference(
     tag_prefix = f"{random.randint(100, 9999)}"
     repository = "test-repo"
 
-    child_image = await create_child_image(oci_client, repository, tag_prefix)
-    index_image = await create_index_image(
+    child_image = await img_utils.create_child_image(oci_client, repository, tag_prefix)
+    index_image = await img_utils.create_index_image(
         oci_client,
         repository,
         tag_prefix,
         child_image,
     )
-    child_sbom = await generate_child_image_sbom(child_image, tmp_path)
-    index_sbom = await generate_index_image_sbom(index_image, tmp_path)
+    child_sbom = await img_utils.generate_child_image_sbom(child_image, tmp_path)
+    index_sbom = await img_utils.generate_index_image_sbom(index_image, tmp_path)
 
     assert is_main_package_present_in_other_sbom(child_sbom, index_sbom, True), (
         "Child image SBOM is not referenced in the index SBOM"


### PR DESCRIPTION
A new test aims to verify the SBOMs produced by the Mobster is aligned with the Conforma rules.

A test generates image, index image and generates SBOM for both. In order to verify the Conforma rules both images needs to be signed and attestation needs to be provided. The attestation is dynamically generate based on what is being produced by Konflux build.

JIRA: ISV-6206

The test discovered an issue in Conforma that is addressed here: https://github.com/conforma/policy/pull/1531