### PR TITLE
test: mock oras dependency to prevent subprocess calls

### DIFF
--- a/tests/cmd/generate/oci_image/test_module_init.py
+++ b/tests/cmd/generate/oci_image/test_module_init.py
@@ -55,7 +55,11 @@ def image_digest_file_content() -> list[str]:
 @patch(
     "mobster.cmd.generate.oci_image.base_images_dockerfile.get_base_images_digests_lines"
 )
+@patch(
+    "mobster.cmd.generate.oci_image.base_images_dockerfile.get_digest_for_image_ref"
+)
 async def test_GenerateOciImageCommand_execute(
+    mock_get_digest_for_image_ref: AsyncMock,
     mock_get_base_images_digests_lines: MagicMock,
     test_case: GenerateOciImageTestCase,
     image_digest_file_content: str,
@@ -63,6 +67,9 @@ async def test_GenerateOciImageCommand_execute(
     # Set up mock for base image digest content if base_image_digest_file is present
     if test_case.args.base_image_digest_file is not None:
         mock_get_base_images_digests_lines.return_value = image_digest_file_content
+    else:
+        # Prevent the test from hitting the network or calling 'oras'
+        mock_get_digest_for_image_ref.return_value = "sha256:3191d33c484a1cfe5d559200aa75670c41770abf3316244c28eec20a8dba3e0c"
 
     command = GenerateOciImageCommand(test_case.args)
 

--- a/tests/cmd/generate/oci_image/test_module_init.py
+++ b/tests/cmd/generate/oci_image/test_module_init.py
@@ -55,9 +55,7 @@ def image_digest_file_content() -> list[str]:
 @patch(
     "mobster.cmd.generate.oci_image.base_images_dockerfile.get_base_images_digests_lines"
 )
-@patch(
-    "mobster.cmd.generate.oci_image.base_images_dockerfile.get_digest_for_image_ref"
-)
+@patch("mobster.cmd.generate.oci_image.base_images_dockerfile.get_digest_for_image_ref")
 async def test_GenerateOciImageCommand_execute(
     mock_get_digest_for_image_ref: AsyncMock,
     mock_get_base_images_digests_lines: MagicMock,

--- a/tests/cmd/generate/oci_image/test_module_init.py
+++ b/tests/cmd/generate/oci_image/test_module_init.py
@@ -69,7 +69,9 @@ async def test_GenerateOciImageCommand_execute(
         mock_get_base_images_digests_lines.return_value = image_digest_file_content
     else:
         # Prevent the test from hitting the network or calling 'oras'
-        mock_get_digest_for_image_ref.return_value = "sha256:3191d33c484a1cfe5d559200aa75670c41770abf3316244c28eec20a8dba3e0c"
+        mock_get_digest_for_image_ref.return_value = (
+            "sha256:3191d33c484a1cfe5d559200aa75670c41770abf3316244c28eec20a8dba3e0c"
+        )
 
     command = GenerateOciImageCommand(test_case.args)
 


### PR DESCRIPTION
Fixes #354

## Summary
This PR fixes a bug where our local unit tests were unintentionally trying to execute the real oras command-line tool. Because unit tests do not actually require oras to be installed to verify our Python logic, this oversight was causing problems and crashing tests on developers' machines. By mocking out the oras network call, we've made this test suite faster, completely offline, and immediately runnable for beginners who don't have oras installed locally

## Screenshots

**Before (test failing without `oras`):**
<img width="937" height="434" alt="Screenshot 2026-03-27 192501" src="https://github.com/user-attachments/assets/b2110167-3da0-426c-a9f8-b5c5a159fcda" />


**After (all tests passing):**
<img width="956" height="489" alt="Screenshot 2026-03-27 192540" src="https://github.com/user-attachments/assets/0b03eaa1-4eba-4deb-9bd4-04494a464526" />
