### PR TITLE
fix(ISV-7072): support custom CA bundles 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -61,7 +61,10 @@ COPY LICENSE /licenses/
 ENV PATH=/app/.venv/bin:$PATH
 ENV PATH=/app/bin:$PATH
 
-USER 1001
+# Allow user to update CA trust
+RUN chmod -R g+w /etc/pki/
+
+USER 1001:0
 
 # Set the command to run your application
 CMD [".venv/bin/mobster"]

--- a/tasks/augment-component-sboms-ta/0.3/README.md
+++ b/tasks/augment-component-sboms-ta/0.3/README.md
@@ -27,6 +27,9 @@ Update component-level SBOMs with release-time information, optionally upload th
 | `fulcioExternalUrl`       | string |                           | The external URL of the Fulcio certificate authority.                                                                              |
 | `tufExternalUrl`          | string |                           | The external URL of the TUF repository.                                                                                            |
 | `buildIdentityRegexp`     | string |                           | A regular expression to extract build identity from the OIDC token claims, if applicable.                                          |
+| `caTrustConfigMapName`    | string |                           | The name of the ConfigMap to read CA bundle data from.                                                                             |
+| `caTrustConfigMapKey`     | string |                           | The name of the key in the ConfigMap that contains the CA bundle data.                                                             |
+| `caCertPath`              | string |                           | Path to CA certificate bundle for TLS verification with self-signed certificates.                                                  |
 
 ## Secrets
 The augment-component-sboms-ta Task optionally depends on two secrets. If they

--- a/tasks/augment-component-sboms-ta/0.3/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.3/augment-component-sboms-ta.yaml
@@ -296,6 +296,14 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -eux
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        system_bundle=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+        if [ -f "$ca_bundle" ]; then
+          echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+          cat "$ca_bundle" >> "$system_bundle"
+        fi
+
         # This is a little fragile, ideally it would be just a param. It's here
         # for consistency with other tasks in release-service-catalog. The
         # script below will verify that the release_id has the correct format.

--- a/tasks/augment-component-sboms-ta/0.3/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.3/augment-component-sboms-ta.yaml
@@ -157,6 +157,18 @@ spec:
         A regular expression to extract build identity from the OIDC token claims, if applicable.
       default: ""
 
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data
+      default: ca-bundle.crt
+    - name: caCertPath
+      type: string
+      description: Path to CA certificate bundle for TLS verification with self-signed certificates
+      default: /mnt/trusted-ca/ca-bundle.crt
 
   results:
     - description: Produced trusted data artifact
@@ -174,11 +186,21 @@ spec:
               # 30 minutes should be enough to finish this task
               expirationSeconds: 1800
               path: oidc-token
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
 
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
     env:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.ociArtifactExpiresAfter)
@@ -346,3 +368,5 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(results.sourceDataArtifact.path)
+        - name: caCertPath
+          value: $(params.caCertPath)


### PR DESCRIPTION
These changes have been tested in a cluster with overriden CA configuration for IngressController (this manual testing was assisted by Claude-4.6-Opus, but the code is an update of #360 and #361 created manually).