### PR TITLE
chore(ISV-7022): prioritize internal urls in augment script

### DIFF
--- a/tasks/augment-component-sboms-ta/0.3/README.md
+++ b/tasks/augment-component-sboms-ta/0.3/README.md
@@ -26,6 +26,10 @@ Update component-level SBOMs with release-time information, optionally upload th
 | `rekorExternalUrl`        | string |                           | The external URL of the Rekor transparency log.                                                                                    |
 | `fulcioExternalUrl`       | string |                           | The external URL of the Fulcio certificate authority.                                                                              |
 | `tufExternalUrl`          | string |                           | The external URL of the TUF repository.                                                                                            |
+| `rekorInternalUrl`        | string |                           | The internal URL of the Rekor transparency log.                                                                                    |
+| `fulcioInternalUrl`       | string |                           | The internal URL of the Fulcio certificate authority.                                                                              |
+| `tufInternalUrl`          | string |                           | The internal URL of the TUF repository.                                                                                            |
+
 | `buildIdentityRegexp`     | string |                           | A regular expression to extract build identity from the OIDC token claims, if applicable.                                          |
 
 ## Secrets

--- a/tasks/augment-component-sboms-ta/0.3/augment-component-sboms-ta.yaml
+++ b/tasks/augment-component-sboms-ta/0.3/augment-component-sboms-ta.yaml
@@ -143,13 +143,25 @@ spec:
       type: string
       description: The external URL of the Rekor transparency log.
       default: ""
+    - name: rekorInternalUrl
+      type: string
+      description: The internal URL of the Rekor transparency log.
+      default: ""
     - name: fulcioExternalUrl
       type: string
       description: The external URL of the Fulcio certificate authority.
       default: ""
+    - name: fulcioInternalUrl
+      type: string
+      description: The internal URL of the Fulcio certificate authority.
+      default: ""
     - name: tufExternalUrl
       type: string
       description: The external URL of the TUF repository.
+      default: ""
+    - name: tufInternalUrl
+      type: string
+      description: The internal URL of the TUF repository.
       default: ""
     - name: buildIdentityRegexp
       type: string
@@ -289,26 +301,32 @@ spec:
           --result-dir "$(params.resultsDirPath)"
           --release-data "$(params.releaseData)"
         )
+
+        # Initialize URL parameters to the right value (prioritizing internal url)
+        rekorUrl="$(params.rekorInternalUrl)"; rekorUrl="${rekorUrl:-$(params.rekorExternalUrl)}"
+        fulcioUrl="$(params.fulcioInternalUrl)"; fulcioUrl="${fulcioUrl:-$(params.fulcioExternalUrl)}"
+        tufUrl="$(params.tufInternalUrl)"; tufUrl="${tufUrl:-$(params.tufExternalUrl)}"
+
         # Params are basically Bash commands, their value
         # has to be checked with -n. Env variables should
         # be checked with -v to not leak expanded secrets
         # through xtrace. Bash conditionals ([[) have to
         # be used instead of Shell conditionals ([) to use -v
         if [[ -n "$(params.defaultOIDCIssuer)" \
-          && -n "$(params.rekorExternalUrl)" \
-          && -n "$(params.fulcioExternalUrl)" \
-          && -n "$(params.tufExternalUrl)" \
+          && -n "${rekorUrl}" \
+          && -n "${fulcioUrl}" \
+          && -n "${tufUrl}" \
           && -n "$(params.buildIdentityRegexp)" \
         ]]; then
           # Keyless signing is used for augmentation
-          cosign initialize --root "$(params.tufExternalUrl)/root.json" \
-            --mirror "$(params.tufExternalUrl)"
+          cosign initialize --root "${tufUrl}/root.json" \
+            --mirror "${tufUrl}"
           mobster_args+=(
             --oidc-token /var/run/sigstore/cosign/oidc-token
-            --fulcio-url "$(params.fulcioExternalUrl)"
+            --fulcio-url "${fulcioUrl}"
             --oidc-issuer "$(params.defaultOIDCIssuer)"
             --oidc-identity-pattern "$(params.buildIdentityRegexp)"
-            --rekor-url "$(params.rekorExternalUrl)"
+            --rekor-url "${rekorUrl}"
           )
         elif [[ -n "$(params.attestationPubKey)" \
           && -v SIGN_KEY \


### PR DESCRIPTION
This has been tested using tsf-cli in a test instance of Konlfux. I ordered a dev openshift cluster like this https://devhub.corp.redhat.com/itcp/catalogitems

I updated the pipelines with the changes and verified no errors were present during exceution. I attach here logs proving it (step process-component-sbom): 
[managed-m727z-process-component-sbom.log](https://github.com/user-attachments/files/26740881/managed-m727z-process-component-sbom.log)
