### PR TITLE
fix(ISV-6997): normalize --arch flag to OCI format before use

### DIFF
--- a/docs/sboms/oci_image.md
+++ b/docs/sboms/oci_image.md
@@ -54,6 +54,7 @@ mobster --verbose  generate oci-image \
 - `--metadata-path` -- points to a Dockerfile/Containerfile metadata YAML file
 - `--contextualize` -- Allows SBOM contextualization (see [Contextual SBOM](#contextual-sbom))
 - `--output` -- where to save the SBOM. prints it to STDOUT if this is not specified
+- `--arch` -- Image architecture in OCI format (e.g., `amd64`, `arm64`, `ppc64le`, `s390x`). Linux kernel format values (e.g., `x86_64`, `aarch64`) are also accepted and normalized automatically to the OCI format. Defaults to the architecture of the current system.
 - `--skip-validation` -- skips validation of the SBOM
 
 ## Generating a (non-hermetic) SBOM from scratch

--- a/src/mobster/cli.py
+++ b/src/mobster/cli.py
@@ -19,6 +19,7 @@ from mobster.cmd.generate import (
 from mobster.cmd.upload import upload
 from mobster.image import PULLSPEC_PATTERN
 from mobster.release import ReleaseId
+from mobster.utils import normalize_arch
 
 
 def setup_arg_parser() -> argparse.ArgumentParser:
@@ -129,8 +130,15 @@ def generate_oci_image_parser(subparsers: Any) -> None:
     )
     oci_image_parser.add_argument(
         "--arch",
-        type=str,
-        help="Image architecture. If not selected the OS arch is used.",
+        type=normalize_arch,
+        help=(
+            "Image architecture in OCI format (e.g., amd64, arm64, ppc64le, s390x). "
+            "Linux kernel format values (e.g., x86_64, aarch64) are also accepted "
+            "and normalized automatically to the OCI format. "
+            "Defaults to the architecture of the current system."
+        ),
+        # default=None ensures normalize_arch is only called when --arch is explicitly
+        # provided
         default=None,
     )
     oci_image_parser.add_argument(

--- a/src/mobster/cmd/generate/oci_image/hermeto_sbom_filter.py
+++ b/src/mobster/cmd/generate/oci_image/hermeto_sbom_filter.py
@@ -122,7 +122,8 @@ def _filter_spdx_sbom_by_arch(
 
     Args:
         sbom_dict: The SBOM dictionary
-        target_arch: The architecture to filter by (e.g., "x86_64", "aarch64")
+        target_arch: The architecture to filter by in OCI (e.g., "amd64")
+                     or kernel format (e.g., "x86_64")
 
     Returns:
         dict[str, Any]: The filtered SBOM dictionary
@@ -169,7 +170,8 @@ def _filter_cyclonedx_sbom_by_arch(
 
     Args:
         sbom_dict: The SBOM dictionary
-        target_arch: The architecture to filter by (e.g., "x86_64", "aarch64")
+        target_arch: The architecture to filter by in OCI (e.g., "amd64")
+                     or kernel format (e.g., "x86_64")
 
     Returns:
         dict[str, Any]: The filtered SBOM dictionary
@@ -230,7 +232,8 @@ def filter_hermeto_sbom_by_arch(
 
     Args:
         sbom_dict: The SBOM dictionary
-        target_arch: The architecture to filter by (e.g., "x86_64", "aarch64")
+        target_arch: The architecture to filter by in OCI (e.g., "amd64")
+                     or kernel format (e.g., "x86_64")
 
     Returns:
         dict[str, Any]: The filtered SBOM dictionary

--- a/src/mobster/utils.py
+++ b/src/mobster/utils.py
@@ -80,23 +80,40 @@ async def run_async_subprocess(
     return code, stdout, stderr
 
 
+def normalize_arch(arch: str) -> str:
+    """
+    Normalize an architecture string to OCI manifest format.
+
+    Accepts architecture values in either OCI format (e.g., "amd64")
+    or Linux kernel format (e.g., "x86_64") and returns the OCI format.
+    Values already in OCI format or unknown values are passed through unchanged.
+
+    Args:
+        arch: Architecture string in any recognized format.
+
+    Returns:
+        OCI manifest compatible arch identifier.
+    """
+    if arch in ARCH_TRANSLATION_MAP:
+        return arch
+    for oci_arch, kernel_arches in ARCH_TRANSLATION_MAP.items():
+        if arch in kernel_arches:
+            return oci_arch
+    return arch
+
+
 def identify_arch() -> str:
     """
     Fetches the runtime arch and converts it to oci manifest arch format.
 
     Returns:
-        oci manifest compatible arch identifier.
+        OCI manifest compatible arch identifier.
     """
-
-    platform_arch = platform.machine()
-
-    for oci_arch, uname_arches in ARCH_TRANSLATION_MAP.items():
-        if platform_arch in uname_arches:
-            return oci_arch
-    LOGGER.warning(
-        "Unknown architecture '%s'. Using 'unknown' as fallback.", platform_arch
-    )
-    return platform_arch
+    arch = platform.machine()
+    result = normalize_arch(arch)
+    if result == arch and arch not in ARCH_TRANSLATION_MAP:
+        LOGGER.warning("Unknown architecture '%s'. Using as-is.", arch)
+    return result
 
 
 async def load_sbom_from_json(file_path: Path) -> dict[str, Any]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,3 +159,23 @@ def test_identify_arch(
     mock_platform.return_value = input_arch
     arch = utils.identify_arch()
     assert arch == expected_arch
+
+
+@pytest.mark.parametrize(
+    "input_arch, expected_arch",
+    [
+        pytest.param("amd64", "amd64", id="oci-amd64-passthrough"),
+        pytest.param("arm64", "arm64", id="oci-arm64-passthrough"),
+        pytest.param("ppc64le", "ppc64le", id="oci-ppc64le-passthrough"),
+        pytest.param("s390x", "s390x", id="oci-s390x-passthrough"),
+        pytest.param("x86_64", "amd64", id="kernel-x86_64"),
+        pytest.param("x64", "amd64", id="kernel-x64"),
+        pytest.param("aarch64", "arm64", id="kernel-aarch64"),
+        pytest.param("armv8l", "arm64", id="kernel-armv8l"),
+        pytest.param("ppc64", "ppc64le", id="kernel-ppc64"),
+        pytest.param("s390", "s390x", id="kernel-s390"),
+        pytest.param("riscv64", "riscv64", id="unknown-passthrough"),
+    ],
+)
+def test_normalize_arch(input_arch: str, expected_arch: str) -> None:
+    assert utils.normalize_arch(input_arch) == expected_arch


### PR DESCRIPTION
When --arch is passed with a Linux kernel format value (e.g., x86_64), it can break multiple things, like the image self-reference architecture, parent image resolution, passing architecture flag to oras, etc.

Add normalize_arch() to convert any recognized kernel-format arch string to OCI format at the entry points, and refactor identify_arch() to delegate to it. Document the --arch flag behavior in CLI help and docs.

This shouldn't affect exisiting workflows that rely on architecture - hermeto filtering can handle both conventions (but tagging @brunoapimentel to be sure) and everything else needs OCI format. 

Assisted-by: Claude Code (Claude Opus 4.6)

