### PR TITLE
fix: log correct number of remaining packages

### DIFF
--- a/src/mobster/cmd/generate/oci_image/hermeto_sbom_filter.py
+++ b/src/mobster/cmd/generate/oci_image/hermeto_sbom_filter.py
@@ -152,7 +152,7 @@ def _filter_spdx_sbom_by_arch(
         "Filtered %s packages out of %s (%s remaining)",
         removed_count,
         original_count,
-        removed_count,
+        filtered_count,
     )
 
     return {


### PR DESCRIPTION
After applying the Hermeto filter, Mobster currently logs a message like

    Filtered 0 packages out of 720 (0 remaining)

This looks scary at first sight, but the result is as expected: the SBOM doesn't filter any packages and keeps all of them.

Correct the log message to actually log the number of remaining packages for the "N remaining" part (instead of the number of removed packages).