### PR TITLE
chore(ISV-7207): improve agentready score with documentation, CI, and tooling improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: 'fix: '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear description of what the bug is -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Environment
+
+- Mobster version:
+- OS:
+- Python version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+<!-- A clear description of the feature you'd like -->
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- How would you like this to be implemented? -->
+
+## Alternatives Considered
+
+<!-- Any alternative solutions or features you've considered -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- Describe the changes in this PR -->
+
+## Related Issues
+
+Fixes #
+
+## Testing
+
+- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
+- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
+- [ ] Konflux CI pipeline passes
+
+## Checklist
+
+- [ ] Documentation updated if needed
+- [ ] Coverage remains at 95%+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,38 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   tox:
-    name: Run unit tests and linters
+    name: ${{ matrix.tox-env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Running all tox environments including pytest
+        tox-env: [test, ruff, pylint, mypy, yamllint, bandit, pip-audit]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.4.1
+
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction --no-root
+
+      - name: Run ${{ matrix.tox-env }}
+        run: poetry run tox -e ${{ matrix.tox-env }}
+
+      - name: Upload coverage reports to Codecov
+        if: matrix.tox-env == 'test'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
+  hadolint:
+    name: hadolint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -25,24 +56,14 @@ jobs:
         run: |
           poetry install --no-interaction --no-root
 
-      - name: Install Hadolint and Oras via Brew
+      - name: Install Hadolint
         run: |
-          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          /home/linuxbrew/.linuxbrew/bin/brew install hadolint oras
-          sudo ln -s /home/linuxbrew/.linuxbrew/bin/hadolint /usr/bin/
-          sudo ln -s /home/linuxbrew/.linuxbrew/bin/oras /usr/bin/
+          curl -sSL https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64 \
+            -o /usr/local/bin/hadolint
+          chmod +x /usr/local/bin/hadolint
 
-      - name: Run Tests
-        run: |
-            poetry run tox run --skip-env test-integration
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unit-tests
-          files: ./coverage.xml
-          fail_ci_if_error: false
+      - name: Run hadolint
+        run: poetry run tox -e hadolint
 
   commitlint:
     name: Conventional Commit Lint

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Editor and OS files
+.vscode/
+*.swp
+*.swo
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
     rev: v8.29.1
     hooks:
       - id: gitleaks
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Mobster is a Python tool for generating and managing Software Bill of Materials (SBOMs) in SPDX and CycloneDX formats. It is used within the Konflux CI/CD platform to produce SBOMs for OCI images, OCI indexes, product releases, modelcar images, OCI artifacts, and PKO packages. SBOMs can be uploaded to Trusted Profile Analyzer (TPA) or stored in S3.
+
+## Setup
+
+```bash
+# Install Poetry, then:
+poetry install
+poetry shell
+```
+
+## Common Commands
+
+### Testing
+```bash
+tox -e test                              # Run all unit tests (excludes integration)
+tox -e test -- -k test_name             # Run a specific test by name
+tox -e test -- -v                        # Verbose output
+tox -e test-integration                  # Run integration tests (requires docker compose up -d)
+```
+
+Coverage must stay at 95%+. Slow tests are marked with `@pytest.mark.slow` and excluded by default.
+
+### Linting & Formatting
+```bash
+tox -e ruff                  # Check formatting and lint (ruff)
+tox -e ruff-fix              # Auto-fix formatting and lint issues
+tox -e pylint                # Run pylint
+tox -e mypy                  # Run mypy (strict mode)
+tox -e bandit                # Run bandit security checks
+tox -e yamllint              # Lint YAML files
+tox                          # Run all checks (test, ruff, pylint, bandit, mypy, yamllint, pip-audit, hadolint)
+
+# Single-file checks (fast feedback):
+tox -e ruff -- src/mobster/some_file.py  # lint one file
+tox -e mypy -- src/mobster/some_file.py  # type-check one file
+```
+
+### Build
+```bash
+podman build -t <image_name> .    # Build container image
+podman run -it <image_name>       # Run container
+```
+
+## Architecture
+
+### Package Layout
+
+```
+src/mobster/
+  cli.py              # argparse CLI setup
+  main.py             # Entry point: parses args, runs async command
+  cmd/                # Command implementations (Command ABC pattern)
+    base.py           # Abstract Command base class (execute + save)
+    generate/         # SBOM generation commands per artifact type
+      oci_image/      # OCI image SBOM generation (most complex)
+        contextual_sbom/  # Contextualization: matches packages to base/builder images
+    augment/          # Augments existing SBOMs with release metadata, CPEs, signing
+    upload/           # Upload SBOMs to TPA (with OIDC auth)
+    download/         # Download SBOMs from TPA
+    delete/           # Delete SBOMs from TPA
+  sbom/               # SPDX and CycloneDX model utilities
+    spdx.py           # SPDX document/package builders
+    cyclonedx.py      # CycloneDX document/component builders
+    merge.py          # Merge multiple SBOM documents
+  oci/                # OCI registry interactions
+    __init__.py       # oras-based manifest fetch, docker auth file handling
+    artifact.py       # OCI artifact helpers
+    cosign/           # cosign signature verification (static key, keyless, rekor)
+  tekton/             # Tekton task entry points (component + product processing)
+  regenerate/         # Batch SBOM regeneration utilities
+  artifact.py         # Artifact dataclass (oci-copy schema)
+  image.py            # Image dataclass with pullspec/digest parsing
+  release.py          # ReleaseId type
+  syft.py             # Syft SBOM parsing utilities
+  utils.py            # Async subprocess helpers
+```
+
+### Command Pattern
+
+All CLI commands implement `Command` (abstract base in `cmd/base.py`) with two async methods:
+- `execute()` — perform the operation, store result
+- `save()` — write output to disk or remote
+
+The CLI dispatcher in `main.py` calls both sequentially after `argparse` resolves `args.func` to a `Command` subclass.
+
+### SBOM Generation Flow (OCI Image)
+
+The most complex path: `generate oci-image` merges Syft and Hermeto SBOMs, adds base image relationships from a parsed Dockerfile, optionally contextualizes packages to their source base/builder image, and validates the result.
+
+### Tekton Entry Points
+
+`process_component_sboms` and `process_product_sbom` scripts (in `tekton/`) are used as Tekton task steps. They orchestrate augment + upload + S3 push in a single call and use S3/Atlas-specific config beyond the standard CLI.
+
+### External Tools
+
+- **oras** — fetching OCI manifests
+- **cosign** — signature verification for image provenance
+- **syft** — generating raw SBOMs from container images (output is parsed by mobster)
+
+### SBOM Formats
+
+Both SPDX (`spdx-tools` library) and CycloneDX (`cyclonedx-python-lib`) are supported. Most generation commands default to CycloneDX; OCI image generation produces SPDX.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,16 @@ The most complex path: `generate oci-image` merges Syft and Hermeto SBOMs, adds 
 - **cosign** — signature verification for image provenance
 - **syft** — generating raw SBOMs from container images (output is parsed by mobster)
 
+## Pattern References
+
+Common change types and reference implementations to follow:
+
+- **New generate command**: see `src/mobster/cmd/generate/modelcar.py` (simplest example of a full generate command)
+- **New augment step**: see `src/mobster/cmd/augment/` for the augment command pattern
+- **New CLI argument**: see `src/mobster/cli.py` — add argument to the relevant `*_command_parser` function and wire it to the `Command` subclass via `set_defaults`
+- **New SBOM utility (SPDX)**: see `src/mobster/sbom/spdx.py`
+- **New SBOM utility (CycloneDX)**: see `src/mobster/sbom/cyclonedx.py`
+
 ### SBOM Formats
 
 Both SPDX (`spdx-tools` library) and CycloneDX (`cyclonedx-python-lib`) are supported. Most generation commands default to CycloneDX; OCI image generation produces SPDX.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ ecosystem. To use those features, you need to install the following tools:
 - [**cosign**](https://github.com/sigstore/cosign): Used for signing and verifying SBOM documents in OCI registries.
 - [**syft**](https://github.com/anchore/syft): Used for generating SBOM documents from container images and filesystems.
 
+## Usage
+
+```bash
+# Generate an SBOM for an OCI image (merging Syft and Hermeto outputs)
+mobster generate --output sbom.json oci-image \
+  --from-syft syft-sbom.json \
+  --image-pullspec registry.example.com/repo:tag \
+  --image-digest sha256:<digest>
+
+# Augment SBOMs for all images in a snapshot
+mobster augment --output sboms/ oci-image --snapshot snapshot.json
+
+# Upload a single SBOM to Trusted Profile Analyzer
+mobster upload tpa \
+  --tpa-base-url https://your-tpa-instance.com \
+  --file sbom.json
+
+# See all available commands and options
+mobster --help
+mobster generate --help
+```
+
 ## Development environment
 
 Follow an instruction in the [development-environment.md](docs/development-environment.md)

--- a/docs/adr/0001-command-pattern-for-cli.md
+++ b/docs/adr/0001-command-pattern-for-cli.md
@@ -1,0 +1,33 @@
+# 1. Command Pattern for CLI
+
+Date: 2026-05-25
+
+## Status
+
+Accepted
+
+## Context
+
+Mobster exposes multiple CLI subcommands (generate, augment, upload, download, delete), each
+requiring distinct logic for producing output and persisting it. A consistent structure is needed
+to keep subcommand implementations uniform, testable, and easy to extend.
+
+## Decision
+
+All CLI subcommands implement the `Command` abstract base class defined in `src/mobster/cmd/base.py`.
+Each command provides two async methods:
+
+- `execute()` — performs the operation and stores the result internally
+- `save()` — writes the result to disk or a remote destination
+
+The CLI dispatcher in `main.py` calls both sequentially after `argparse` resolves the subcommand
+to a `Command` subclass via `args.func`.
+
+## Consequences
+
+- Adding a new subcommand requires implementing `Command` and registering it in `cli.py` — a
+  clear, low-friction extension point
+- `execute()` and `save()` can be tested independently
+- All commands are async, enabling concurrent operations (e.g. parallel uploads)
+- The two-phase design couples output production to persistence, which may require workarounds
+  if a command needs to stream output incrementally in the future

--- a/docs/adr/0002-dual-sbom-format-support.md
+++ b/docs/adr/0002-dual-sbom-format-support.md
@@ -1,0 +1,28 @@
+# 2. Dual SBOM Format Support (SPDX and CycloneDX)
+
+Date: 2026-05-25
+
+## Status
+
+Accepted
+
+## Context
+
+Two SBOM formats have broad industry adoption: SPDX (ISO/IEC 5962:2021) and CycloneDX.
+Konflux CI pipelines and downstream consumers (e.g. Trusted Profile Analyzer) may expect
+either format depending on the artifact type and pipeline stage.
+
+## Decision
+
+Mobster supports both SPDX and CycloneDX formats. The `sbom/` package provides separate
+modules for each (`spdx.py`, `cyclonedx.py`) backed by their respective libraries
+(`spdx-tools` and `cyclonedx-python-lib`). OCI image generation produces SPDX; most other
+generation commands default to CycloneDX with an `--sbom-type` flag to switch.
+
+## Consequences
+
+- Consumers can receive SBOMs in their preferred format without format conversion
+- Two sets of model utilities must be maintained in parallel
+- Cross-format merging is not supported; all inputs to a merge operation must be in the
+  same format
+- New features (e.g. new relationship types) must be implemented in both format modules

--- a/docs/adr/0003-asyncio-for-concurrent-operations.md
+++ b/docs/adr/0003-asyncio-for-concurrent-operations.md
@@ -1,0 +1,29 @@
+# 3. AsyncIO for Concurrent Operations
+
+Date: 2026-05-25
+
+## Status
+
+Accepted
+
+## Context
+
+SBOM generation and processing involves many I/O-bound operations: fetching OCI manifests
+via oras, downloading SBOMs from TPA, verifying signatures with cosign, and uploading
+results. Processing snapshots with many images sequentially would be prohibitively slow
+in CI pipelines.
+
+## Decision
+
+The entire Mobster codebase uses Python's asyncio for concurrency. All `Command`
+implementations are async, the CLI entry point runs via `asyncio.run()`, and I/O-bound
+operations use async subprocess helpers (`utils.py`). Concurrency limits are exposed as
+`--concurrency` flags on commands that fan out across multiple images.
+
+## Consequences
+
+- Snapshot processing and bulk uploads scale to many images without threading complexity
+- All new commands and utilities must be written as async functions
+- Synchronous libraries (e.g. `spdx-tools`) are called directly since they are CPU-bound
+  and do not block the event loop significantly
+- Testing async code requires `pytest-asyncio`

--- a/docs/sboms/oci_image_augmentation.md
+++ b/docs/sboms/oci_image_augmentation.md
@@ -13,11 +13,11 @@ You can either augment a specific OCI image by providing the optional
 `--reference` argument, or augment SBOMs for all images in the supplied
 snapshot:
 ```bash
-$ mobster augment oci-image --output sboms/ oci-image \
+$ mobster augment --output sboms/ oci-image \
     --reference quay.io/repo/image@sha256:<digest> \
     --snapshot snapshot.json
 
-$ mobster augment oci-image --output sboms/ oci-image \
+$ mobster augment --output sboms/ oci-image \
     --snapshot snapshot.json
 ```
 
@@ -58,7 +58,7 @@ package for our single-arch component:
 
 We can now run the command:
 ```bash
-$ mobster augment oci-image --output sboms/ snapshot \
+$ mobster augment --output sboms/ oci-image \
     --snapshot snapshot.json
 ```
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,8 @@ commands = pytest -v \
 
 [testenv:ruff]
 commands =
-    ruff check .
-    ruff format --check .
+    ruff check {posargs:.}
+    ruff format --check {posargs:.}
 
 [testenv:ruff-fix]
 commands =
@@ -52,22 +52,22 @@ commands =
 
 [testenv:pylint]
 commands =
-    pylint --disable=too-few-public-methods {[vars]PACKAGE_MODULE}
+    pylint --disable=too-few-public-methods {posargs:{[vars]PACKAGE_MODULE}}
 
 [testenv:mypy]
 commands =
-    mypy {[vars]PACKAGE_MODULE} {[vars]PACKAGE_TESTS}
+    mypy {posargs:{[vars]PACKAGE_MODULE} {[vars]PACKAGE_TESTS}}
 
 [testenv:yamllint]
 files =
     .
 commands =
-    yamllint {[testenv:yamllint]files}
+    yamllint {posargs:{[testenv:yamllint]files}}
 
 
 [testenv:bandit]
 groups = operatorcert-dev
-commands = bandit -r {[vars]PACKAGE_MODULE} -ll
+commands = bandit -r {posargs:{[vars]PACKAGE_MODULE}} -ll
 
 [testenv:pip-audit]
 groups = operatorcert-dev


### PR DESCRIPTION
Summary:                                                                                                                                                     
                                                                                                                                                               
  This branch addresses multiple agentready assessment items to improve repository readiness for AI-assisted development.                                      
                                                                                                                                                               
  Changes by category:                                                                                                                                         
                                                                                                                                                               
  - Documentation                                                                                                                                              
    - Added Usage section to README with correct CLI examples; fixed augment command example in docs/sboms/oci_image_augmentation.md                           
    - Added 3 Architecture Decision Records (ADRs): Command pattern, dual SBOM format support, asyncio usage                                                   
    - Added Pattern References section to CLAUDE.md with guidance for common extension points
  - GitHub templates
    - Added PR template (.github/PULL_REQUEST_TEMPLATE.md) with testing checklist referencing docs
    - Added bug report and feature request issue templates
  - CI
    - Refactored .github/workflows/test.yaml to run each tox environment as a separate matrix job, enabling per-check visibility in GitHub Actions
  - Tooling
    - Added conventional-pre-commit hook for commit message linting
    - Added posargs support to tox.ini for ruff, mypy, pylint, bandit, and yamllint — enables single-file checks (e.g. tox -e ruff -- src/mobster/some_file.py)
    - Added missing editor/OS patterns to .gitignore
