### PR TITLE
docs: add CONTRIBUTING guide and improve README structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Mobster
+
+Thank you for your interest in contributing! This guide covers everything you need to get started.
+
+## Getting Started
+
+1. Fork the repository and clone your fork
+2. Set up your local environment — see [docs/development-environment.md](docs/development-environment.md)
+3. Install pre-commit hooks (includes gitleaks secret detection and conventional commit linting):
+   ```bash
+   pre-commit install --hook-type commit-msg
+   pre-commit install
+   ```
+
+## Making Changes
+
+- Create a branch from `main` for your change
+- Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for commit messages:
+  - `feat: add support for OCI artifact SBOMs`
+  - `fix: correct purl normalization for rpm packages`
+  - `docs: update augment command examples`
+- Keep commits focused — one logical change per commit
+- For significant design decisions, consider adding an [ADR](docs/adr/) (see existing ADRs for format)
+
+## Running Checks Locally
+
+See [docs/development-environment.md](docs/development-environment.md) for the full list of tox commands, code formatting, testing, and integration test setup. Test coverage must stay at **95%+**.
+
+## Submitting a Pull Request
+
+1. Push your branch and open a PR against `main`
+2. Fill in the PR template — include what changed and how it was tested
+3. Ensure all CI checks pass
+4. Address review feedback; a maintainer will merge once approved
+
+## Reporting Issues
+
+Use the GitHub issue templates:
+- **Bug report** — for unexpected behavior
+- **Feature request** — for new functionality
+
+## License
+
+By contributing, you agree your changes will be licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The major stages are:
 
 ## Getting started
 
-To use the Mobster tool, you need to install it first. There are multiple ways to isnstall
+To use the Mobster tool, you need to install it first. There are multiple ways to install
 the tool:
 
 ### Using pip
@@ -66,34 +66,13 @@ mobster --help
 mobster generate --help
 ```
 
-## Development environment
-
-Follow an instruction in the [development-environment.md](docs/development-environment.md)
-file to set up your development environment.
-
-
 ## Contributing
-We welcome contributions to the Mobster project! If you would like to contribute, please follow these steps:
 
-1. Fork the repository
-2. Create a new branch for your feature or bug fix
-3. Make your changes and commit them with a clear message (following the
-   [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format)
-   (e.g. `feat: add new feature` or `fix: fix a bug`)
-4. Open a pull request to the main repository
-5. Make sure the CI checks pass and the code is properly formatted
-6. Wait for the review and address any comments or suggestions
-7. Once your changes are approved, they will be merged into the main branch
-8. Congratulations! You have successfully contributed to the Mobster project
+See [CONTRIBUTING.md](CONTRIBUTING.md) for environment setup, running checks, and submitting a pull request.
 
-## Release process
-The release process is automated using GitHub Actions and Konflux. The process
-is described in detail in the [release.md](./release.md) file.
+## Resources
 
-## Documentation
-The documentation for the Mobster project is available
-at the [Mobster Gitbub pages](https://konflux-ci.dev/mobster/).
-
-## License
-This project is licensed under the Apache License 2.0. See the
-[LICENSE](https://github.com/konflux-ci/mobster/blob/main/LICENSE) file for details.
+- [Development environment](docs/development-environment.md)
+- [Release process](docs/release.md)
+- [Full documentation](https://konflux-ci.dev/mobster/)
+- [License](https://github.com/konflux-ci/mobster/blob/main/LICENSE) — Apache License 2.0

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -6,21 +6,24 @@
    1. `poetry install`
    2. This will create a virtual environment in `.venv` and install all dependencies
    3. You can also use `poetry shell` to activate the virtual environment
-3. Install [pre-commit hooks](#git-leaks-detection)
+3. Install [pre-commit hooks](#pre-commit-hooks)
 
 Note: You can also use a custom virtual environment based on your preference.
 
-### Git leaks detection
+### Pre-commit hooks
 
-Since the repository currently contains secret information in various encrypted forms there is high chance that developer may push a commit with
-decrypted secrets by mistake. To avoid this problem we recommend
-to use `Gitleaks` tool that prevent you from commit secret code into git history.
+The repository uses pre-commit hooks for:
+- **Gitleaks** — prevents accidentally committing secrets
+- **Conventional commits** — validates commit message format on `commit-msg`
 
-The repository is already pre-configured but each developer has to make final
-config changes in his/her environment.
+Install both hook types after cloning:
 
-Follow the [documentation](https://github.com/gitleaks/gitleaks#pre-commit) to
-configure Gitleaks on your computer.
+```bash
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+See the [Gitleaks documentation](https://github.com/gitleaks/gitleaks#pre-commit) if you need additional Gitleaks configuration on your machine.
 
 ## Package management
 The project uses Poetry for package management. You can use the following commands to manage packages:


### PR DESCRIPTION
- Add CONTRIBUTING.md with environment setup, commit conventions, PR workflow, and issue reporting
- Restructure README: remove redundant sections, fix typos, merge thin sections into a Resources bullet list, reference CONTRIBUTING.md
- Update docs/development-environment.md: expand pre-commit section to cover both hook types (pre-commit and commit-msg)