### PR TITLE
ci: allow pip-audit to fail without blocking PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         # Running all tox environments including pytest
-        tox-env: [test, ruff, pylint, mypy, yamllint, bandit, pip-audit]
+        tox-env: [test, ruff, pylint, mypy, yamllint, bandit]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.4.1
@@ -41,6 +41,30 @@ jobs:
           flags: unit-tests
           files: ./coverage.xml
           fail_ci_if_error: false
+
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Check for poetry.lock changes
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
+        with:
+          files: poetry.lock
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.4.1
+
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction --no-root
+
+      - name: Run pip-audit
+        continue-on-error: ${{ steps.changed-files.outputs.any_changed != 'true' }}
+        run: poetry run tox -e pip-audit
 
   hadolint:
     name: hadolint
@@ -70,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Check AGENTS.md is under 150 lines
         run: |


### PR DESCRIPTION
Move pip-audit out of the shared tox matrix into a dedicated job with continue-on-error: true so failures are visible but non-blocking.

## Summary

<!-- Describe the changes in this PR -->

## Related Issues

Fixes #

## Testing

- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
