### PR TITLE
feat(ISV-7382): re-implement backward compatibility with dockerfile-json

### DIFF
--- a/docs/sboms/oci_image.md
+++ b/docs/sboms/oci_image.md
@@ -57,6 +57,12 @@ mobster --verbose  generate oci-image \
 - `--arch` -- Image architecture in OCI format (e.g., `amd64`, `arm64`, `ppc64le`, `s390x`). Linux kernel format values (e.g., `x86_64`, `aarch64`) are also accepted and normalized automatically to the OCI format. Defaults to the architecture of the current system.
 - `--skip-validation` -- skips validation of the SBOM
 
+### Deprecated arguments (will be removed in future versions and fully replaced by --metadata-path)
+- `--parsed-dockerfile-path` -- points to a dockerfile processed by `dockerfile-json`. Use `--metadata-path` instead.
+- `--base-image-digest-file` -- points to a file with digests for images used in Dockerfile. Expected format: `<registry>/<repository>:<tag> <registry>/<repository>:<tag>@sha256:<digest>`. Use `--metadata-path` instead.
+- `--dockerfile-target` -- the name of the build target from the Dockerfile. Use `--metadata-path` instead.
+- `--additional-base-image` -- base (builder) image to add, can be specified multiple times. Expects the format `<registry>/<repository>:<tag>@sha256:<digest value>`. Use `--metadata-path` instead.
+
 ## Generating a (non-hermetic) SBOM from scratch
 
 To build an SBOM with only the OCI image, you will need to run several tools to
@@ -98,6 +104,25 @@ mobster generate \
 
 Once the command is complete, you should see the full Mobster SBOM in
 `full-sbom.json` in your working directory.
+
+### Deprecated: using dockerfile-json instead of buildprobe
+
+For backward compatibility, you can still use the deprecated `dockerfile-json`
+based workflow. 
+Note: This path only supports parent contextualization (no builder content).
+It will be removed in a future version. Full contextualization parent + builder
+content can be achieved only by use of the --metadata-path argument.
+
+```sh
+mobster generate \
+	--output full-sbom.json \
+	oci-image \
+	--from-syft syft.json \
+	--parsed-dockerfile-path containerfile.json \
+	--base-image-digest-file base_images_digests.txt \
+	--image-pullspec quay.io/konflux-ci/mobster:latest \
+	--image-digest sha256:1234567890abcdef...
+```
 
 ## Contextual SBOM
 

--- a/src/mobster/cli.py
+++ b/src/mobster/cli.py
@@ -17,7 +17,7 @@ from mobster.cmd.generate import (
     product,
 )
 from mobster.cmd.upload import upload
-from mobster.image import PULLSPEC_PATTERN
+from mobster.image import ARTIFACT_PATTERN, PULLSPEC_PATTERN
 from mobster.release import ReleaseId
 from mobster.utils import normalize_arch
 
@@ -158,6 +158,44 @@ def generate_oci_image_parser(subparsers: Any) -> None:
             "Required for builder contextualization."
         ),
     )
+
+    def validated_additional_reference(value: str) -> str:
+        assert re.match(ARTIFACT_PATTERN, value), (
+            "Additional references must be in the format "
+            "<registry>/<repository>:<tag>@sha256:<digest>"
+        )
+        return value
+
+    oci_image_parser.add_argument(
+        "--parsed-dockerfile-path",
+        type=Path,
+        help="[Deprecated: use --metadata-path] Path to the parsed Dockerfile file",
+    )
+    oci_image_parser.add_argument(
+        "--base-image-digest-file",
+        type=Path,
+        help="[Deprecated: use --metadata-path] Path to the file containing references "
+        "to images in the Dockerfile and their digests. "
+        "Expected format: "
+        "`<registry>/<repository>:<tag> <registry>/<repository>:<tag>@sha256:<digest>`",
+    )
+    oci_image_parser.add_argument(
+        "--dockerfile-target",
+        type=str,
+        default=None,
+        help="[Deprecated: use --metadata-path] "
+        "The name of the build target from the Dockerfile",
+    )
+    oci_image_parser.add_argument(
+        "--additional-base-image",
+        type=validated_additional_reference,
+        action="append",
+        default=[],
+        help="[Deprecated: use --metadata-path] "
+        "Base (builder) image to add, can be specified multiple times. "
+        "Expects the format <registry>/<repository>:<tag>@sha256:<digest value>",
+    )
+
     oci_image_parser.set_defaults(func=oci_image.GenerateOciImageCommand)
 
 

--- a/src/mobster/cmd/generate/oci_image/__init__.py
+++ b/src/mobster/cmd/generate/oci_image/__init__.py
@@ -38,7 +38,9 @@ from mobster.cmd.generate.oci_image.hermeto_sbom_filter import (
 from mobster.cmd.generate.oci_image.metadata import SBOMMetadata
 from mobster.cmd.generate.oci_image.sbom_utils import (
     extend_sbom_with_base_images,
+    get_base_images_refs_from_dockerfile,
     get_digest_for_image_ref,
+    get_image_objects_from_file,
 )
 from mobster.cmd.generate.oci_image.spdx_utils import (
     DocumentIndexOCI,
@@ -101,11 +103,27 @@ class GenerateOciImageCommand(GenerateCommandWithOutputTypeSelector):
     def _load_metadata(self) -> None:
         """
         Load a metadata file from the --metadata-path argument into
-        self._metadata.
+        self._metadata. If the file does not exist (e.g. buildprobe failed),
+        self._metadata remains unset and the deprecated dockerfile-json
+        fallback path is used.
         """
-        with open(self.cli_args.metadata_path, encoding="utf-8") as metadata_file:
-            raw_metadata = yaml.safe_load(metadata_file)
-            self._metadata = SBOMMetadata.model_validate(raw_metadata)
+        try:
+            with open(self.cli_args.metadata_path, encoding="utf-8") as metadata_file:
+                raw_metadata = yaml.safe_load(metadata_file)
+                if raw_metadata is None:
+                    raise ValueError("metadata file is empty")
+                self._metadata = SBOMMetadata.model_validate(raw_metadata)
+        except (
+            FileNotFoundError,
+            ValueError,
+            yaml.YAMLError,
+        ) as exc:
+            LOGGER.warning(
+                "Cannot load metadata file %s (%s), "
+                "falling back to deprecated dockerfile-json path",
+                self.cli_args.metadata_path,
+                exc,
+            )
 
     async def _handle_bom_inputs(
         self,
@@ -298,8 +316,9 @@ class GenerateOciImageCommand(GenerateCommandWithOutputTypeSelector):
         base_images_refs = []
         base_images_map: dict[str, Image] = {}
 
-        # Extend with image reference
-        if self.cli_args.metadata_path:
+        # Use buildprobe metadata if loaded successfully, otherwise fall back to
+        # deprecated dockerfile-json path
+        if self._metadata is not None:
             image = self._metadata.image.to_image(image_arch)
             await extend_sbom_with_image_reference(sbom, image, is_builder_image=False)
             for base_image_data in self._metadata.base_images:
@@ -335,6 +354,46 @@ class GenerateOciImageCommand(GenerateCommandWithOutputTypeSelector):
             LOGGER.warning(
                 "Provided image digest but no pullspec. The digest value is ignored."
             )
+
+        # Deprecated fallback if buildprobe metadata are not available:
+        # dockerfile-json input, support for parent contextualization only.
+        if not self._metadata:
+            # Extending with base images references from a dockerfile
+            if self.cli_args.parsed_dockerfile_path:
+                with open(
+                    self.cli_args.parsed_dockerfile_path, encoding="utf-8"
+                ) as parsed_dockerfile_io:
+                    parsed_dockerfile = json.load(parsed_dockerfile_io)
+
+                base_images_refs = await get_base_images_refs_from_dockerfile(
+                    parsed_dockerfile, self.cli_args.dockerfile_target
+                )
+
+                if self.cli_args.base_image_digest_file:
+                    LOGGER.debug(
+                        "Supplied pre-parsed image digest file, will operate offline."
+                    )
+                    base_images_map = await get_image_objects_from_file(
+                        self.cli_args.base_image_digest_file
+                    )
+                await extend_sbom_with_base_images(
+                    sbom, base_images_refs, base_images_map
+                )
+
+            # Extending with additional base images
+            for image_ref in self.cli_args.additional_base_image:
+                image_object = Image.from_oci_artifact_reference(image_ref)
+                await extend_sbom_with_image_reference(
+                    sbom, image_object, is_builder_image=True
+                )
+
+            # Builder contextualization not supported in deprecated path
+            if self.cli_args.build_metadata_path:
+                LOGGER.warning(
+                    "--build-metadata-path is ignored in deprecated fallback path. "
+                    "Builder contextualization requires successful buildprobe metadata."
+                )
+                self.cli_args.build_metadata_path = None
 
         with log_elapsed("Contextual workflow", logging.INFO):
             contextual_sbom = await self._assess_and_dispatch_contextual_workflow(

--- a/src/mobster/cmd/generate/oci_image/__init__.py
+++ b/src/mobster/cmd/generate/oci_image/__init__.py
@@ -290,7 +290,7 @@ class GenerateOciImageCommand(GenerateCommandWithOutputTypeSelector):
         LOGGER.info("Could not create contextual SBOM.")
         return None
 
-    async def execute(self) -> Any:
+    async def execute(self) -> Any:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """
         Generate an SBOM document for OCI image.
         """

--- a/src/mobster/cmd/generate/oci_image/__init__.py
+++ b/src/mobster/cmd/generate/oci_image/__init__.py
@@ -103,9 +103,8 @@ class GenerateOciImageCommand(GenerateCommandWithOutputTypeSelector):
     def _load_metadata(self) -> None:
         """
         Load a metadata file from the --metadata-path argument into
-        self._metadata. If the file does not exist (e.g. buildprobe failed),
-        self._metadata remains unset and the deprecated dockerfile-json
-        fallback path is used.
+        self._metadata. If the file cannot be loaded (e.g. buildprobe failed),
+        self._metadata remains unset.
         """
         try:
             with open(self.cli_args.metadata_path, encoding="utf-8") as metadata_file:

--- a/src/mobster/cmd/generate/oci_image/sbom_utils.py
+++ b/src/mobster/cmd/generate/oci_image/sbom_utils.py
@@ -2,7 +2,9 @@
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from cyclonedx.model import Property
@@ -55,6 +57,117 @@ async def get_digest_for_image_ref(image_ref: str, arch: Any = None) -> str | No
             stderr.decode(),
         )
         return None
+
+
+async def get_base_images_refs_from_dockerfile(
+    parsed_dockerfile: dict[str, Any], target_stage: str | None = None
+) -> list[str | None]:
+    """
+    Reads the base images from provided parsed dockerfile, does not include
+    stages after the target of the build. So the last image returned is
+    the parent image used.
+
+    Deprecated: use --metadata-path with buildprobe output instead.
+
+    Args:
+        parsed_dockerfile (dict[str, Any]): Contents of the parsed dockerfile
+        target_stage (str): The target stage for the build
+    Returns:
+        list[str | None]: List of base images used during build as extracted
+                          from the dockerfile in the order they were used.
+                          `FROM SCRATCH` is identified as `None`.
+
+    Example:
+    If the Dockerfile looks like
+    FROM registry.access.redhat.com/ubi8/ubi:latest as builder
+    ...
+    FROM builder
+    ...
+
+    Then the relevant part of parsed_dockerfile look like
+    {
+        "Stages": [
+            {
+                "BaseName": "registry.access.redhat.com/ubi8/ubi:latest",
+                "As": "builder",
+                "From": {"Image": "registry.access.redhat.com/ubi8/ubi:latest"},
+            },
+            {
+                "BaseName": "builder",
+                "From": {"Stage": {"Named": "builder", "Index": 0}},
+            },
+        ]
+    },
+    """
+    base_images_pullspecs: list[str | None] = []
+    for stage in parsed_dockerfile.get("Stages", []):
+        is_actually_image = True
+
+        from_field = stage.get("From", {})
+        # Ignore scratch image as well as
+        # references to previous stages
+        if "Stage" in from_field:
+            is_actually_image = False
+        if from_field.get("Scratch"):
+            # It is an empty image
+            base_images_pullspecs.append(None)
+            is_actually_image = False
+        base_name: str = stage.get("BaseName")
+        if is_actually_image and base_name and not base_name.startswith("oci-archive:"):
+            # flatpak archives are not real base images. So we skip them
+            base_images_pullspecs.append(base_name.strip("'\""))
+
+        # Don't include images after the target used for build
+        alias = stage.get("As")
+        if target_stage and alias and alias == target_stage:
+            # The `AS` keyword of this stage matches the target
+            break
+        if target_stage and not alias and base_name == target_stage:
+            # This stage does not use the `AS` keyword,
+            # the pull-spec matches the target
+            break
+    return base_images_pullspecs
+
+
+def get_base_images_digests_lines(base_images_digests: Path) -> list[str]:
+    """
+    Return lines of the base_images_digests file.
+
+    Deprecated: use --metadata-path with buildprobe output instead.
+
+    Args:
+        base_images_digests: File containing the digests of images.
+            expects the format <image_ref> <name>:<tag>@sha256:<digest>
+
+    Returns
+        List of file lines.
+    """
+    with open(base_images_digests, encoding="utf-8") as input_file_stream:
+        return list(input_file_stream)
+
+
+async def get_image_objects_from_file(base_images_digests: Path) -> dict[str, Image]:
+    """
+    Parses the base image digest file into a dictionary of
+    image references present in a Dockerfile and Image
+    objects.
+
+    Deprecated: use --metadata-path with buildprobe output instead.
+
+    Args:
+        base_images_digests (Path): File containing the digests of images.
+            expects the format <image_ref> <name>:<tag>@sha256:<digest>
+
+    Returns:
+        dict[str, Image]: Mapping of the references to Image objects
+    """
+    base_images_mapping = {}
+    for line in get_base_images_digests_lines(base_images_digests):
+        line = line.strip()
+        image_ref, image_full_reference = re.split(r"\s+", line)
+        image_obj = Image.from_oci_artifact_reference(image_full_reference.strip("'\""))
+        base_images_mapping[image_ref.strip("'\"")] = image_obj
+    return base_images_mapping
 
 
 async def get_objects_for_base_images(

--- a/tests/cmd/generate/oci_image/test_base_image_utils.py
+++ b/tests/cmd/generate/oci_image/test_base_image_utils.py
@@ -30,6 +30,8 @@ from mobster.cmd.generate.oci_image.sbom_utils import (
     _get_images_and_their_annotations,
     _get_spdx_packages_from_base_images,
     extend_sbom_with_base_images,
+    get_base_images_refs_from_dockerfile,
+    get_image_objects_from_file,
     get_objects_for_base_images,
 )
 from mobster.image import Image
@@ -885,3 +887,111 @@ async def test_extend_sbom_with_base_images(
             mock_image_refs,
             mock_get_objects_for_base_images.return_value,
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ["dockerfile_sample", "target_stage", "expected_list"],
+    [
+        (1, "", ["alpine:3.10", None]),
+        (1, "build", ["alpine:3.10"]),
+        (
+            2,
+            "",
+            [
+                "registry.access.redhat.com/ubi8/ubi:latest",
+                "alpine:3.10",
+                None,
+                "registry.access.redhat.com/ubi9/ubi:latest",
+                "registry.access.redhat.com/ubi8/ubi:latest",
+            ],
+        ),
+        (
+            2,
+            "nothing",
+            [
+                "registry.access.redhat.com/ubi8/ubi:latest",
+                "alpine:3.10",
+                None,
+            ],
+        ),
+        (
+            2,
+            "foo",
+            [
+                "registry.access.redhat.com/ubi8/ubi:latest",
+                "alpine:3.10",
+                None,
+                "registry.access.redhat.com/ubi9/ubi:latest",
+            ],
+        ),
+        (
+            2,
+            "bar",
+            [
+                "registry.access.redhat.com/ubi8/ubi:latest",
+                "alpine:3.10",
+                None,
+                "registry.access.redhat.com/ubi9/ubi:latest",
+                "registry.access.redhat.com/ubi8/ubi:latest",
+            ],
+        ),
+        (
+            2,
+            "registry.access.redhat.com/ubi8/ubi:latest",
+            ["registry.access.redhat.com/ubi8/ubi:latest"],
+        ),
+    ],
+)
+async def test_get_base_images_refs_from_dockerfile(
+    dockerfile_sample: int,
+    target_stage: str,
+    expected_list: list[str | None],
+    sample1_parsed_dockerfile: dict[str, Any],
+    sample2_parsed_dockerfile: dict[str, Any],
+) -> None:
+    """Testing deprecated dockerfile-json backward compatibility."""
+    dockerfile = (
+        sample1_parsed_dockerfile
+        if dockerfile_sample == 1
+        else sample2_parsed_dockerfile
+    )
+    assert (
+        await get_base_images_refs_from_dockerfile(dockerfile, target_stage)
+        == expected_list
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ["file_content", "expected_dict"],
+    [
+        (
+            "alpine:3.10 docker.io/library/alpine:3.10"
+            "@sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98\n"
+            "quay.io/foo/bar:spam quay.io/foo/bar:spam@"
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            {
+                "alpine:3.10": Image(
+                    repository="docker.io/library/alpine",
+                    digest="sha256:451eee8bedcb2f029756dc3e9d73bab0e7943c1ac55cff3a4861c52a0fdd3e98",
+                    tag="3.10",
+                    domain="docker.io",
+                ),
+                "quay.io/foo/bar:spam": Image(
+                    repository="quay.io/foo/bar",
+                    digest="sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                    tag="spam",
+                    domain="quay.io",
+                ),
+            },
+        )
+    ],
+)
+@patch("mobster.cmd.generate.oci_image.sbom_utils.get_base_images_digests_lines")
+async def test_get_digests_from_file(
+    mock_get_lines: MagicMock, file_content: str, expected_dict: dict[str, Image]
+) -> None:
+    """Testing deprecated dockerfile-json backward compatibility."""
+    mock_get_lines.return_value = file_content.split("\n")
+    assert await get_image_objects_from_file(MagicMock()) == expected_dict

--- a/tests/cmd/generate/oci_image/test_module_init.py
+++ b/tests/cmd/generate/oci_image/test_module_init.py
@@ -58,6 +58,32 @@ async def test_GenerateOciImageCommand_execute(
     compare_sbom_dicts(sbom_dict, expected_sbom)
 
 
+@pytest.mark.parametrize(
+    ["file_content", "description"],
+    [
+        (None, "non-existent file"),
+        ("", "empty file"),
+        ("{{invalid yaml: [", "invalid yaml"),
+        ("foo: bar\n", "wrong schema"),
+    ],
+)
+def test_load_metadata_fallback(
+    tmp_path: Path,
+    file_content: str | None,
+    description: str,
+) -> None:
+    """Test that _load_metadata falls back gracefully on bad input."""
+    metadata_path = tmp_path / "metadata.yaml"
+    if file_content is not None:
+        metadata_path.write_text(file_content)
+
+    args = MagicMock()
+    args.metadata_path = metadata_path
+    command = GenerateOciImageCommand(args)
+    command._load_metadata()
+    assert command._metadata is None, f"Expected fallback for: {description}"
+
+
 @pytest.mark.asyncio
 async def test_GenerateOciImageCommand_execute_cannot_contextualize_cyclonedx(
     test_case_cyclonedx_with_additional: GenerateOciImageTestCase,
@@ -105,6 +131,7 @@ async def test_GenerateOciImageCommand_execute_handle_pullspec(
     args.image_pullspec = pullspec
     args.image_digest = digest
     args.metadata_path = None
+    args.parsed_dockerfile_path = None
     command = GenerateOciImageCommand(args)
     if expected_action == "error":
         with pytest.raises(ValueError):
@@ -137,6 +164,7 @@ async def test_GenerateOciImageCommand_execute_unknown_sbom(
     args.image_pullspec = None
     args.image_digest = None
     args.metadata_path = None
+    args.parsed_dockerfile_path = None
     command = GenerateOciImageCommand(args)
     with pytest.raises(ValueError):
         await command.execute()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,6 +266,11 @@ class GenerateOciImageCommandArgs:
     contextualize: bool = False
     skip_validation: bool = False
     arch: str | None = None
+    build_metadata_path: Path | None = None
+    parsed_dockerfile_path: Path | None = None
+    base_image_digest_file: Path | None = None
+    dockerfile_target: str | None = None
+    additional_base_image: list[str] | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Deprecated CLI args (--parsed-dockerfile-path, --base-image-digest-file, --dockerfile-target, --additional-base-image) are re-added alongside --metadata-path (buildprobe output).

- Decision between new and deprecated path is at runtime: if metadata file loads successfully, buildprobe path is used. If it fails (file missing, empty, invalid YAML, wrong schema), fallback to deprecated dockerfile-json path with a warning.

- When deprecated path is active, only parent contextualization runs. --build-metadata-path (capo output) is ignored with a warning. (We do not want mix dockerfile-json output with capo output.)

- Restored tests: test_get_base_images_refs_from_dockerfile and test_get_digests_from_file for deprecated parsing functions. Added test_load_metadata_fallback for metadata loading failure modes.

- Not restored: test_GenerateOciImageCommand_execute_missing_digest and image_digest_file_content fixture - low value for temporary deprecated functionality.

- Integration tests and some unit tests were rewritten in PR #351 to use --metadata-path and were not duplicated back for the deprecated path.


## Related PR

#351 

## Testing

- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
