### PR TITLE
fix: Translate the architecture string when filtering CycloneDx SBOMs

### DIFF
--- a/src/mobster/cmd/generate/oci_image/hermeto_sbom_filter.py
+++ b/src/mobster/cmd/generate/oci_image/hermeto_sbom_filter.py
@@ -200,7 +200,14 @@ def _filter_cyclonedx_sbom_by_arch(
 
         arch, checksum = _extract_arch_and_checksum_from_purl(purl)
 
-        if arch == "noarch":
+        # If the target architecture was identified by Mobster, consider all
+        # the potential values returned by Python's platform.machine method
+        if target_arch in ARCH_TRANSLATION_MAP:
+            filter_set = {"noarch", *ARCH_TRANSLATION_MAP[target_arch]}
+        else:
+            filter_set = {"noarch", target_arch}
+
+        if arch in filter_set:
             if not checksum or checksum not in noarch_checksums:
                 filtered_components.append(component)
                 noarch_checksums.add(checksum)
@@ -211,8 +218,6 @@ def _filter_cyclonedx_sbom_by_arch(
                     component.get("version"),
                     checksum,
                 )
-        elif arch == target_arch:
-            filtered_components.append(component)
         else:
             LOGGER.debug(
                 "Removing component %s@%s with arch=%s",
@@ -220,6 +225,17 @@ def _filter_cyclonedx_sbom_by_arch(
                 component.get("version"),
                 arch,
             )
+
+    original_count = len(components)
+    filtered_count = len(filtered_components)
+    removed_count = original_count - filtered_count
+
+    LOGGER.info(
+        "Filtered %s packages out of %s (%s remaining)",
+        removed_count,
+        original_count,
+        filtered_count,
+    )
 
     return {**sbom_dict, "components": filtered_components}
 

--- a/tests/cmd/generate/oci_image/test_hermeto_sbom_filter.py
+++ b/tests/cmd/generate/oci_image/test_hermeto_sbom_filter.py
@@ -156,6 +156,12 @@ class TestFilterHermetoCycloneDXSbomByArch:
                 id="x86_64",
             ),
             pytest.param(
+                "amd64",
+                ALWAYS_KEPT_CYCLONEDX_COMPONENTS
+                | {"pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&checksum=sha256:abc123"},
+                id="x86_64-arch-identified-by-mobster",
+            ),
+            pytest.param(
                 "aarch64",
                 ALWAYS_KEPT_CYCLONEDX_COMPONENTS
                 | {


### PR DESCRIPTION
## Summary

When processing the SBOMs generated by Hermeto, Mobster performs the filtering of RPMs from unrelated architectures. However, there is an amount of variation of how the same architecture can be represented in the string format (e.g. x86 and arm64).

This variation was already being handled for SPDX SBOMs, this commit ports the same logic to also cover CycloneDx SBOMs.

## Related Issues

Fixes STONEBLD-4678.

## Testing

- [x] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [x] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
