### PR TITLE
feat(ISV-7121): cosign v3 is used

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/konflux-ci/task-runner@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea AS golang
+FROM quay.io/konflux-ci/task-runner@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b AS golang
 FROM registry.access.redhat.com/ubi9/python-312@sha256:bb8fd1ba3f7c4c28f04e124654ad95bf575cf5015d768e0bd523196b9d903d52 AS builder
 
 # Set the working directory in the container

--- a/src/mobster/oci/artifact.py
+++ b/src/mobster/oci/artifact.py
@@ -19,6 +19,17 @@ from mobster.image import parse_image_reference
 logger = logging.getLogger(__name__)
 
 
+def get_payload_from_attestation_bytes(attestation_bytes: bytes) -> str:
+    """Returns the B64-encoded payload of this attestation."""
+    loaded_attestation_dict = json.loads(attestation_bytes)
+    if (
+        loaded_attestation_dict.get("mediaType")
+        == "application/vnd.dev.sigstore.bundle.v0.3+json"
+    ):
+        return loaded_attestation_dict["dsseEnvelope"]["payload"]  # type: ignore[no-any-return]
+    return loaded_attestation_dict["payload"]  # type: ignore[no-any-return]
+
+
 class SLSAParsingError(Exception):
     """
     Exception raised when parsing SLSA provenance data fails.
@@ -54,8 +65,9 @@ class SLSAProvenance:
                 statement is missing a predicateType field, or some required
                 provenance content cannot be decoded.
         """
-        encoded = json.loads(attestation)
-        statement = json.loads(base64.b64decode(encoded["payload"]))
+        statement = json.loads(
+            base64.b64decode(get_payload_from_attestation_bytes(attestation))
+        )
 
         predicate_type = statement.get("predicateType")
         if predicate_type is None:

--- a/src/mobster/oci/cosign/__init__.py
+++ b/src/mobster/oci/cosign/__init__.py
@@ -2,11 +2,10 @@
 
 from mobster.oci.cosign.anonymous_fetcher import AnonymousFetcher
 from mobster.oci.cosign.config import (
-    KeylessSignConfig,
     KeylessVerifyConfig,
-    RekorConfig,
     SignConfig,
     StaticSignConfig,
+    URLSigningConfig,
     VerifyConfig,
 )
 from mobster.oci.cosign.keyless import KeylessSBOMFetcher, KeylessSigner
@@ -28,7 +27,11 @@ def get_cosign_fetcher(config: VerifyConfig) -> SupportsFetch:
     Returns:
         Cosign client
     """
-    if config.keyless_verify_config is not None and config.rekor_config is not None:
+    if (
+        config.keyless_verify_config
+        and config.keyless_verify_config.oidc_issuer
+        and config.keyless_verify_config.identity_pattern
+    ):
         return KeylessSBOMFetcher(config)
     if config.static_verify_key is not None:
         return StaticKeyFetcher(config)
@@ -49,7 +52,7 @@ def get_cosign_signer(config: SignConfig) -> SupportsSign:
     Returns:
         Cosign signer
     """
-    if config.keyless_config is not None and config.rekor_config is not None:
+    if config.url_config.is_keyless_ready() and config.keyless_token_file is not None:
         return KeylessSigner(config)
     if (
         config.static_sign_config is not None
@@ -64,20 +67,19 @@ def get_cosign_signer(config: SignConfig) -> SupportsSign:
 
 
 __all__ = [
+    "URLSigningConfig",
     "get_cosign_fetcher",
     "get_cosign_signer",
     "SignConfig",
     "VerifyConfig",
-    "KeylessVerifyConfig",
     "StaticSignConfig",
-    "KeylessSignConfig",
-    "RekorConfig",
     "SupportsSign",
     "SupportsFetch",
     "SupportsProvenanceFetch",
     "AnonymousFetcher",
     "KeylessSBOMFetcher",
     "KeylessSigner",
+    "KeylessVerifyConfig",
     "StaticKeyFetcher",
     "StaticKeySigner",
 ]

--- a/src/mobster/oci/cosign/attestation_utils.py
+++ b/src/mobster/oci/cosign/attestation_utils.py
@@ -5,7 +5,7 @@ import json
 from base64 import b64decode
 from typing import Literal
 
-from mobster.oci.artifact import SBOM, SBOMFormat
+from mobster.oci.artifact import SBOM, SBOMFormat, get_payload_from_attestation_bytes
 
 
 def get_sbom_from_attestation_bytes(
@@ -13,6 +13,8 @@ def get_sbom_from_attestation_bytes(
 ) -> SBOM:
     """
     Parse an SBOM from an Attestation bytes.
+    Supports both attestations produced by Cosign v2 and v3
+    (Cosign Bundles).
     Args:
         attestation_bytes: The raw attestation bytes.
             Must be only a single attestation!
@@ -21,7 +23,9 @@ def get_sbom_from_attestation_bytes(
         SBOM object from this attestation.
     """
     return SBOM(
-        json.loads(b64decode(json.loads(attestation_bytes)["payload"]))["predicate"],
+        json.loads(b64decode(get_payload_from_attestation_bytes(attestation_bytes)))[
+            "predicate"
+        ],
         hashlib.sha256(attestation_bytes).hexdigest(),
         image_reference,
     )

--- a/src/mobster/oci/cosign/config.py
+++ b/src/mobster/oci/cosign/config.py
@@ -107,9 +107,12 @@ class URLSigningConfig:
     )
     tsa_urls: list[URL] = Field(serialization_alias="tsaUrls", default_factory=list)
     rekor_tlog_config: ServiceConfig = Field(
-        default_factory=lambda: ServiceConfig("ANY")
+        serialization_alias="rekorTlogConfig",
+        default_factory=lambda: ServiceConfig("ANY"),
     )
-    tsa_config: ServiceConfig = Field(default_factory=lambda: ServiceConfig("ANY"))
+    tsa_config: ServiceConfig = Field(
+        serialization_alias="tsaConfig", default_factory=lambda: ServiceConfig("ANY")
+    )
 
     def set_tlog_url(self, *urls: str) -> "URLSigningConfig":
         """

--- a/src/mobster/oci/cosign/config.py
+++ b/src/mobster/oci/cosign/config.py
@@ -154,10 +154,14 @@ class URLSigningConfig:
         Yields:
             The path to the Cosign Signing Config file.
         """
-        with tempfile.NamedTemporaryFile(delete_on_close=False, delete=True) as f:
-            f.write(TypeAdapter(type(self)).dump_json(self))
-            f.close()
-            yield Path(f.name)
+        tempdir = tempfile.TemporaryDirectory()
+        try:
+            sign_config_path = Path(tempdir.name).joinpath("signing_config.json")
+            with open(sign_config_path, "wb") as f:
+                f.write(TypeAdapter(type(self)).dump_json(self, by_alias=True))
+            yield sign_config_path
+        finally:
+            tempdir.cleanup()
 
     def is_keyless_ready(self) -> bool:
         """

--- a/src/mobster/oci/cosign/config.py
+++ b/src/mobster/oci/cosign/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from pydantic import BeforeValidator, Field, PlainSerializer, TypeAdapter
-from pydantic.dataclasses import dataclass
+from pydantic.dataclasses import dataclass as pdc_dataclass
 
 
 def _serialize_datetime(value: datetime) -> str:
@@ -31,7 +31,7 @@ def _validate_config_selector(value: str) -> str:
     )
 
 
-@dataclass
+@pdc_dataclass
 class ValidFor:
     """
     Type for specifying validity of a URL.
@@ -43,7 +43,7 @@ class ValidFor:
     )
 
 
-@dataclass
+@pdc_dataclass
 class URL:
     """
     Type for specifying a URL.
@@ -68,7 +68,7 @@ class URL:
         )
 
 
-@dataclass
+@pdc_dataclass
 class ServiceConfig:
     """
     Type for specifying a Sigstore service configuration about
@@ -86,7 +86,7 @@ def _get_urls(*urls: str) -> list[URL]:
     return result_urls
 
 
-@dataclass
+@pdc_dataclass
 class URLSigningConfig:
     """
     Signing Configuration for Cosign CLI.
@@ -175,7 +175,7 @@ class URLSigningConfig:
         )
 
 
-@dataclass
+@pdc_dataclass
 class StaticSignConfig:
     """
     Static (using keys) cosign configuration.
@@ -191,7 +191,7 @@ class StaticSignConfig:
     sign_password: bytes = b""
 
 
-@dataclass
+@pdc_dataclass
 class KeylessVerifyConfig:
     """
     Class holding information needed to verify a Cosign Signing Config.
@@ -207,7 +207,7 @@ class KeylessVerifyConfig:
     oidc_issuer: str
 
 
-@dataclass
+@pdc_dataclass
 class SignConfig:
     """
     Configuration of Cosign keys for signing.
@@ -226,7 +226,7 @@ class SignConfig:
     keyless_token_file: Path | None = Field(default=None)
 
 
-@dataclass
+@pdc_dataclass
 class VerifyConfig:
     """
     Configuration of Cosign keys for verification.

--- a/src/mobster/oci/cosign/config.py
+++ b/src/mobster/oci/cosign/config.py
@@ -1,24 +1,174 @@
 """Configuration for Cosign clients"""
 
 import os
-from dataclasses import dataclass
+import re
+import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Annotated, Any, Literal
+
+from pydantic import BeforeValidator, Field, PlainSerializer, TypeAdapter
+from pydantic.dataclasses import dataclass
+
+
+def _serialize_datetime(value: datetime) -> str:
+    """
+    The time format is specified to contain milliseconds, whereas Python
+    only allows dumping microseconds. 3 digits are stripped.
+    Z specifies the UTC timezone.
+    """
+    return value.strftime("%FT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _validate_config_selector(value: str) -> str:
+    if value in {"ANY", "ALL"} or re.match(r"EXACT:\d+", value):
+        return value
+    raise ValueError(
+        f"Invalid config selector: {value}, "
+        f"see `cosign config create --help` for possible values."
+    )
 
 
 @dataclass
-class RekorConfig:
+class ValidFor:
     """
-    Rekor (TLOG) configuration object definition.
-
-    Attributes:
-        rekor_url:
-            URL of the Rekor server
-        rekor_key:
-            Public key of the Rekor server, optional
+    Type for specifying validity of a URL.
+    Currently only supports the minimal field: start.
     """
 
-    rekor_url: str
-    rekor_key: Path | None = None
+    start: Annotated[datetime, PlainSerializer(_serialize_datetime)] = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+@dataclass
+class URL:
+    """
+    Type for specifying a URL.
+    """
+
+    url: str
+    major_api_version: int = Field(default=1, serialization_alias="majorApiVersion")
+    valid_for: ValidFor = Field(
+        default_factory=ValidFor, serialization_alias="validFor"
+    )
+    operator: str = Field(default="sigstore.dev")
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Omits validity from comparison. Comparison is used just in
+        tests at this point in time.
+        """
+        if not isinstance(other, self.__class__):
+            return False
+        return (
+            self.url == other.url and self.major_api_version == other.major_api_version
+        )
+
+
+@dataclass
+class ServiceConfig:
+    """
+    Type for specifying a Sigstore service configuration about
+    matching the specified URLs.
+    """
+
+    selector: Annotated[str, BeforeValidator(_validate_config_selector)]
+
+
+def _get_urls(*urls: str) -> list[URL]:
+    result_urls = []
+    for url in urls:
+        if isinstance(url, str):
+            result_urls.append(URL(url=url))
+    return result_urls
+
+
+@dataclass
+class URLSigningConfig:
+    """
+    Signing Configuration for Cosign CLI.
+    See https://raw.githubusercontent.com/sigstore/
+    root-signing/refs/heads/main/targets/signing_config.v0.2.json
+
+    This class implements the builder pattern to easily populate its fields.
+    """
+
+    media_type: Literal["application/vnd.dev.sigstore.signingconfig.v0.2+json"] = Field(
+        serialization_alias="mediaType",
+        default="application/vnd.dev.sigstore.signingconfig.v0.2+json",
+    )
+    ca_urls: list[URL] = Field(serialization_alias="caUrls", default_factory=list)
+    oidc_urls: list[URL] = Field(serialization_alias="oidcUrls", default_factory=list)
+    rekor_tlog_urls: list[URL] = Field(
+        serialization_alias="rekorTlogUrls", default_factory=list
+    )
+    tsa_urls: list[URL] = Field(serialization_alias="tsaUrls", default_factory=list)
+    rekor_tlog_config: ServiceConfig = Field(
+        default_factory=lambda: ServiceConfig("ANY")
+    )
+    tsa_config: ServiceConfig = Field(default_factory=lambda: ServiceConfig("ANY"))
+
+    def set_tlog_url(self, *urls: str) -> "URLSigningConfig":
+        """
+        Builder pattern method for setting the TLog (Rekor) URLs.
+        Args:
+            *urls: Any number of URL strings.
+
+        Returns:
+            Self (the edited object).
+        """
+        self.rekor_tlog_urls = _get_urls(*urls)
+        return self
+
+    def set_fulcio_url(self, *urls: str) -> "URLSigningConfig":
+        """
+        Builder pattern method for setting the Fulcio (CA) URLs.
+        Args:
+            *urls: Any number of URL strings.
+
+        Returns:
+            Self (the edited object).
+        """
+        self.ca_urls = _get_urls(*urls)
+        return self
+
+    def set_issuer_url(self, *urls: str) -> "URLSigningConfig":
+        """
+        Builder pattern method for setting the issuer URLs.
+        Args:
+            *urls: Any number of URL strings.
+
+        Returns:
+            Self (the edited object).
+        """
+        self.oidc_urls = _get_urls(*urls)
+        return self
+
+    @contextmanager
+    def file(self) -> Generator[Path, None, None]:
+        """
+        Context manager for creating a temporary Cosign Signing Config file.
+        Yields:
+            The path to the Cosign Signing Config file.
+        """
+        with tempfile.NamedTemporaryFile(delete_on_close=False, delete=True) as f:
+            f.write(TypeAdapter(type(self)).dump_json(self))
+            f.close()
+            yield Path(f.name)
+
+    def is_keyless_ready(self) -> bool:
+        """
+        Does this config contain information needed for keyless signing?
+        Returns:
+            True if the config contains information needed for keyless
+            signing, False otherwise.
+        """
+        return (
+            self.rekor_tlog_urls != [] and self.oidc_urls != [] and self.ca_urls != []
+        )
 
 
 @dataclass
@@ -38,37 +188,19 @@ class StaticSignConfig:
 
 
 @dataclass
-class KeylessSignConfig:
-    """
-    Keyless (using OIDC) cosign configuration for signing.
-
-    Attributes:
-        fulcio_url:
-            URL to the used certificate authority for keyless signing
-        token_file:
-            Path to OIDC token used for keyless authentication
-    """
-
-    fulcio_url: str
-    token_file: Path
-
-
-@dataclass
 class KeylessVerifyConfig:
     """
-    Keyless (using OIDC) cosign configuration for verification.
+    Class holding information needed to verify a Cosign Signing Config.
 
     Attributes:
-        issuer_url:
-            OIDC Issuer URL for validating token, used for
-            keyless attested SBOM verification
         identity_pattern:
-            RegEx pattern for validating token identity, used for
-            keyless attested SBOM verification
+            Expected signee identity regex pattern
+        oidc_issuer:
+            Expected signee identity (actual URL and not regex)
     """
 
-    issuer_url: str
     identity_pattern: str
+    oidc_issuer: str
 
 
 @dataclass
@@ -77,17 +209,17 @@ class SignConfig:
     Configuration of Cosign keys for signing.
 
     Attributes:
+        url_config:
+            configuration of Sigstore services
         static_sign_config:
             Configuration for static signing
-        rekor_config:
-            Rekor URL and optionally key, used for static and keyless attesting
-        keyless_config:
-            Configuration for keyless signing
+        keyless_token_file:
+            Token file used for keyless signing
     """
 
-    static_sign_config: StaticSignConfig | None = None
-    rekor_config: RekorConfig | None = None
-    keyless_config: KeylessSignConfig | None = None
+    url_config: URLSigningConfig = Field(default_factory=URLSigningConfig)
+    static_sign_config: StaticSignConfig | None = Field(default=None)
+    keyless_token_file: Path | None = Field(default=None)
 
 
 @dataclass
@@ -98,12 +230,10 @@ class VerifyConfig:
     Attributes:
         static_verify_key:
             Verification static key path
-        rekor_config:
-            Rekor URL and optionally key, used for static and keyless attesting
         keyless_verify_config:
-            Keyless verification configuration
+            Configuration for keyless verification
+
     """
 
-    static_verify_key: os.PathLike[str] | None = None
-    rekor_config: RekorConfig | None = None
-    keyless_verify_config: KeylessVerifyConfig | None = None
+    static_verify_key: os.PathLike[str] | None = Field(default=None)
+    keyless_verify_config: KeylessVerifyConfig | None = Field(default=None)

--- a/src/mobster/oci/cosign/keyless.py
+++ b/src/mobster/oci/cosign/keyless.py
@@ -13,8 +13,6 @@ from mobster.oci.cosign.attestation_utils import (
     get_sbom_from_attestation_bytes,
 )
 from mobster.oci.cosign.config import (
-    KeylessSignConfig,
-    RekorConfig,
     SignConfig,
     VerifyConfig,
 )
@@ -48,16 +46,12 @@ class KeylessSBOMFetcher(SupportsFetch):
             raise SBOMError(
                 "Cannot fetch SBOM verifiably, TUF has not been initialized."
             )
-        if not config.rekor_config:
-            raise SBOMError(
-                "Cannot fetch SBOM verifiably, No Rekor information provided."
-            )
         if not config.keyless_verify_config:
             raise SBOMError(
-                "Cannot fetch SBOM verifiably, missing issuer and identity patterns."
+                "Cannot fetch SBOM verifiably, missing "
+                "OIDC issuer or identity information."
             )
-        self.keyless_config = config.keyless_verify_config
-        self.rekor_config = config.rekor_config
+        self.config = config.keyless_verify_config
 
     async def fetch_sbom(self, image: Image) -> SBOM:
         raw_attestation = b""
@@ -69,12 +63,10 @@ class KeylessSBOMFetcher(SupportsFetch):
                     command = [
                         "cosign",
                         "verify-attestation",
-                        "--rekor-url",
-                        self.rekor_config.rekor_url,
                         "--certificate-oidc-issuer",
-                        self.keyless_config.issuer_url,
+                        self.config.oidc_issuer,
                         "--certificate-identity-regexp",
-                        self.keyless_config.identity_pattern,
+                        str(self.config.identity_pattern),
                         "--type",
                         sbom_spec,
                         image.reference,
@@ -106,14 +98,15 @@ class KeylessSigner(SupportsSign):
     def __init__(self, config: SignConfig):
         if (
             not check_tuf()
-            or config.keyless_config is None
-            or config.rekor_config is None
+            or not config.url_config.oidc_urls
+            or not config.url_config.ca_urls
+            or not config.url_config.rekor_tlog_urls
+            or not config.keyless_token_file
         ):
             raise SBOMError(
-                "Cannot attest SBOM, no signing configuration was provided."
+                "Cannot attest SBOM, insufficient signing configuration was provided."
             )
-        self.keyless_config: KeylessSignConfig = config.keyless_config
-        self.rekor_config: RekorConfig = config.rekor_config
+        self.config = config
 
     async def attest_sbom(
         self,
@@ -121,29 +114,28 @@ class KeylessSigner(SupportsSign):
         image_ref: str,
         sbom_format: SBOMFormat,
     ) -> None:
-        cosign_command = [
-            "cosign",
-            "attest",
-            "--yes",
-            "--type",
-            get_cosign_attestation_type(sbom_format),
-            "--rekor-url",
-            str(self.rekor_config.rekor_url),
-            "--fulcio-url",
-            str(self.keyless_config.fulcio_url),
-            "--identity-token",
-            str(self.keyless_config.token_file),
-            "--predicate",
-            str(sbom_path),
-            image_ref,
-        ]
-        with make_oci_auth_file(image_ref) as authfile:
-            cosign_env = {"DOCKER_CONFIG": str(authfile.parent)}
-            code, _, stderr = await run_async_subprocess(
-                cosign_command,
-                env=cosign_env,
-                retry_times=3,
-            )
+        with self.config.url_config.file() as config_file:
+            cosign_command = [
+                "cosign",
+                "attest",
+                "--signing-config",
+                str(config_file.absolute()),
+                "--yes",
+                "--type",
+                get_cosign_attestation_type(sbom_format),
+                "--identity-token",
+                str(self.config.keyless_token_file),
+                "--predicate",
+                str(sbom_path),
+                image_ref,
+            ]
+            with make_oci_auth_file(image_ref) as authfile:
+                cosign_env = {"DOCKER_CONFIG": str(authfile.parent)}
+                code, _, stderr = await run_async_subprocess(
+                    cosign_command,
+                    env=cosign_env,
+                    retry_times=3,
+                )
         if code:
             raise SBOMError(
                 f"Could not attest SBOM ({' '.join(cosign_command)}) "

--- a/src/mobster/oci/cosign/static.py
+++ b/src/mobster/oci/cosign/static.py
@@ -247,6 +247,7 @@ class StaticKeySigner(SupportsSign):
                         cosign_env[env_var_name] = str(env_var_value)
                 with tempfile.NamedTemporaryFile() as sign_key_passwd_file:
                     sign_key_passwd_file.write(self.static_sign_config.sign_password)
+                    sign_key_passwd_file.seek(0)
                     code, _, stderr = await run_async_subprocess(
                         cosign_command,
                         env=cosign_env,

--- a/src/mobster/oci/cosign/static.py
+++ b/src/mobster/oci/cosign/static.py
@@ -19,6 +19,8 @@ from mobster.oci.cosign.attestation_utils import (
 )
 from mobster.oci.cosign.config import (
     SignConfig,
+    StaticSignConfig,
+    URLSigningConfig,
     VerifyConfig,
 )
 from mobster.oci.cosign.protocol import (
@@ -36,8 +38,7 @@ class StaticKeyFetcher(SupportsFetch, SupportsProvenanceFetch):
     Client used to get OCI artifacts using Cosign with static keys.
 
     Attributes:
-        verify_key: Verification (public) key path
-        rekor_config: TLOG configuration
+        config: The configuration for this client instance
     """
 
     def __init__(
@@ -50,8 +51,7 @@ class StaticKeyFetcher(SupportsFetch, SupportsProvenanceFetch):
         Args:
             cosign_config: The configuration for this client instance
         """
-        self.verify_key = cosign_config.static_verify_key
-        self.rekor_config = cosign_config.rekor_config
+        self.config: VerifyConfig = cosign_config
         # Some cosign operations are extremely heavy, requiring a mutex mechanism
         # to not get OOM killed within the pipeline
 
@@ -87,7 +87,7 @@ class StaticKeyFetcher(SupportsFetch, SupportsProvenanceFetch):
             cmd = [
                 "cosign",
                 "verify-attestation",
-                f"--key={self.verify_key}",
+                f"--key={self.config.static_verify_key}",
                 f"--type={attestation_type}",
                 "--insecure-ignore-tlog=true",
                 image.reference,
@@ -191,8 +191,8 @@ class StaticKeySigner(SupportsSign):
     def __init__(self, config: SignConfig):
         if config.static_sign_config is None or not config.static_sign_config.sign_key:
             raise SBOMError("Cannot attest SBOM, no signing key was provided.")
-        self.rekor_config = config.rekor_config
-        self.sign_config = config.static_sign_config
+        self.url_config: URLSigningConfig = config.url_config
+        self.static_sign_config: StaticSignConfig = config.static_sign_config
 
     async def _attest_anything(
         self,
@@ -221,51 +221,43 @@ class StaticKeySigner(SupportsSign):
                 will be attached to
             data_format: Cosign-dependent attestation format
         """
-
-        # Translate SPDX format to a cosign-supported version. See
-        # https://github.com/sigstore/cosign/blob/main/doc/cosign_attest.md#options
-        cosign_command = [
-            "cosign",
-            "attest",
-            "--yes",
-            "--key",
-            str(self.sign_config.sign_key),
-            "--type",
-            data_format,
-            "--predicate",
-            str(file_path),
-            push_reference,
-        ]
-        with make_oci_auth_file(push_reference) as authfile:
-            cosign_env = {"DOCKER_CONFIG": str(authfile.parent)}
-            for env_var_name in (
-                "AWS_DEFAULT_REGION",
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY",
-            ):
-                if env_var_value := os.environ.get(f"COSIGN_{env_var_name}"):
-                    cosign_env[env_var_name] = str(env_var_value)
-            if not self.rekor_config:
-                logger.debug("[Cosign] TLog won't be used for sbom attestation.")
-                cosign_command.insert(-1, "--tlog-upload=false")
-            else:
-                cosign_command.insert(-1, f"--rekor-url={self.rekor_config.rekor_url}")
-                cosign_env["SIGSTORE_REKOR_PUBLIC_KEY"] = str(
-                    self.rekor_config.rekor_key
+        with self.url_config.file() as config_file:
+            cosign_command = [
+                "cosign",
+                "attest",
+                "--signing-config",
+                str(config_file.absolute()),
+                "--yes",
+                "--key",
+                str(self.static_sign_config.sign_key),
+                "--type",
+                data_format,
+                "--predicate",
+                str(file_path),
+                push_reference,
+            ]
+            with make_oci_auth_file(push_reference) as authfile:
+                cosign_env = {"DOCKER_CONFIG": str(authfile.parent)}
+                for env_var_name in (
+                    "AWS_DEFAULT_REGION",
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY",
+                ):
+                    if env_var_value := os.environ.get(f"COSIGN_{env_var_name}"):
+                        cosign_env[env_var_name] = str(env_var_value)
+                with tempfile.NamedTemporaryFile() as sign_key_passwd_file:
+                    sign_key_passwd_file.write(self.static_sign_config.sign_password)
+                    code, _, stderr = await run_async_subprocess(
+                        cosign_command,
+                        env=cosign_env,
+                        retry_times=3,
+                        stdin=sign_key_passwd_file,
+                    )
+            if code:
+                raise SBOMError(
+                    f"Could not attest SBOM ({' '.join(cosign_command)}) "
+                    f"failed with code {code}, STDERR: {stderr.decode()}",
                 )
-            with tempfile.NamedTemporaryFile() as sign_key_passwd_file:
-                sign_key_passwd_file.write(self.sign_config.sign_password)
-                code, _, stderr = await run_async_subprocess(
-                    cosign_command,
-                    env=cosign_env,
-                    retry_times=3,
-                    stdin=sign_key_passwd_file,
-                )
-        if code:
-            raise SBOMError(
-                f"Could not attest SBOM ({' '.join(cosign_command)}) "
-                f"failed with code {code}, STDERR: {stderr.decode()}",
-            )
 
     async def attest_provenance(
         self,
@@ -277,8 +269,9 @@ class StaticKeySigner(SupportsSign):
         Attach a provenance predicate to an image. For test purposes only.
 
         Args:
-            provenance: Provenance object to attach
+            predicate: Provenance object to attach
             image_ref: Reference of image to attach to
+            cosign_type: SLSA provenance version
         """
         # Used in integration tests only, unit-testing won't add any benefit
         # as this is just a wrapper for another function which is covered by
@@ -314,8 +307,14 @@ class StaticKeySigner(SupportsSign):
             image_ref: The image which should be cleaned
             blob_type: What type of attachments should be cleaned
         """
+        cmd = [
+            "cosign",
+            "clean",
+            "--force=true",
+            f"--type={blob_type}",
+            image_ref,
+        ]
         with make_oci_auth_file(image_ref) as authfile:
-            cmd = ["cosign", "clean", "--force=true", f"--type={blob_type}", image_ref]
             code, _, stderr = await run_async_subprocess(
                 cmd, env={"DOCKER_CONFIG": str(authfile.parent)}
             )
@@ -332,39 +331,32 @@ class StaticKeySigner(SupportsSign):
         Args:
             image_ref: The image to sign.
         """
-        if self.sign_config is None:
-            raise SBOMError("Cannot sign image without a signing config")
-        cosign_command = [
-            "cosign",
-            "sign",
-            "--key",
-            str(self.sign_config.sign_key),
-            image_ref,
-        ]
-        with make_oci_auth_file(image_ref) as authfile:
-            cosign_env = {"DOCKER_CONFIG": str(authfile.parent)}
+        with self.url_config.file() as config_file:
+            cosign_command = [
+                "cosign",
+                "sign",
+                "--signing-config",
+                str(config_file.absolute()),
+                "--key",
+                str(self.static_sign_config.sign_key),
+                image_ref,
+            ]
+            with make_oci_auth_file(image_ref) as authfile:
+                cosign_env = {"DOCKER_CONFIG": str(authfile.parent)}
 
-            if not self.rekor_config:
-                logger.debug("[Cosign] TLog won't be used for sbom attestation.")
-                cosign_command.insert(-1, "--tlog-upload=false")
-            else:
-                cosign_command.insert(-1, f"--rekor-url={self.rekor_config.rekor_url}")
-                cosign_env["SIGSTORE_REKOR_PUBLIC_KEY"] = str(
-                    self.rekor_config.rekor_key
-                )
-
-            with tempfile.NamedTemporaryFile() as sign_key_passwd_file:
-                sign_key_passwd_file.write(self.sign_config.sign_password)
-                code, _, stderr = await run_async_subprocess(
-                    cosign_command,
-                    env=cosign_env,
-                    retry_times=3,
-                    stdin=sign_key_passwd_file,
-                )
-            if code != 0:
-                raise RuntimeError(
-                    f"Failed to sign image {image_ref} in registry.\n"
-                    f"CMD: {' '.join(cosign_command)}\n"
-                    f"Error: {stderr.decode()}"
-                )
+                with tempfile.NamedTemporaryFile() as sign_key_passwd_file:
+                    sign_key_passwd_file.write(self.static_sign_config.sign_password)
+                    sign_key_passwd_file.seek(0)
+                    code, _, stderr = await run_async_subprocess(
+                        cosign_command,
+                        env=cosign_env,
+                        retry_times=3,
+                        stdin=sign_key_passwd_file,
+                    )
+                if code != 0:
+                    raise RuntimeError(
+                        f"Failed to sign image {image_ref} in registry.\n"
+                        f"CMD: {' '.join(cosign_command)}\n"
+                        f"Error: {stderr.decode()}"
+                    )
         return None

--- a/src/mobster/tekton/component.py
+++ b/src/mobster/tekton/component.py
@@ -9,7 +9,6 @@ import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeVar
 
 from mobster.cmd.augment import AugmentConfig, SBOMRefDetail, augment_sboms
 from mobster.cmd.generate.product import parse_release_notes
@@ -30,12 +29,6 @@ from mobster.tekton.common import (
 )
 
 LOGGER = logging.getLogger(__name__)
-
-_Conf = TypeVar(
-    "_Conf",
-    cosign.StaticSignConfig,
-    cosign.URLSigningConfig,
-)
 
 
 @dataclass

--- a/src/mobster/tekton/component.py
+++ b/src/mobster/tekton/component.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import tempfile
 from collections.abc import Sequence
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeVar
 
@@ -33,10 +33,8 @@ LOGGER = logging.getLogger(__name__)
 
 _Conf = TypeVar(
     "_Conf",
-    cosign.KeylessSignConfig,
     cosign.StaticSignConfig,
-    cosign.RekorConfig,
-    cosign.KeylessVerifyConfig,
+    cosign.URLSigningConfig,
 )
 
 
@@ -67,13 +65,6 @@ def _add_component_args(parser: ap.ArgumentParser) -> None:
         type=Path,
         help="path to the merged data file in JSON format",
         required=True,
-    )
-    parser.add_argument(
-        "--rekor-key",
-        type=Path,
-        help="The public key file of the rekor server used for SBOM "
-        "attestation within a registry",
-        default=None,
     )
     parser.add_argument(
         "--rekor-url", type=str, help="The URL of the Rekor server", default=None
@@ -119,21 +110,6 @@ def _add_component_args(parser: ap.ArgumentParser) -> None:
     )
 
 
-def _check_empty_config(
-    config: _Conf,
-) -> _Conf | None:
-    """Utility function that nulls a configuration if it is unused."""
-    has_value = False
-    for field in fields(config):
-        field_val = getattr(config, field.name)
-        if field_val is not None and field_val != field.default:
-            has_value = True
-            break
-    if not has_value:
-        return None
-    return config
-
-
 def parse_args(cli_args: Sequence[str] | None = None) -> ProcessComponentArgs:
     """
     Parse command line arguments for component SBOM processing.
@@ -147,32 +123,29 @@ def parse_args(cli_args: Sequence[str] | None = None) -> ProcessComponentArgs:
 
     args = parser.parse_args(args=cli_args)
 
-    rekor_config = _check_empty_config(
-        cosign.RekorConfig(rekor_url=args.rekor_url, rekor_key=args.rekor_key)
-    )
+    static_sign_config = None
+    if args.sign_key:
+        static_sign_config = cosign.StaticSignConfig(
+            sign_key=args.sign_key, sign_password=args.sign_password.encode("utf-8")
+        )
     sign_config = cosign.SignConfig(
-        static_sign_config=_check_empty_config(
-            cosign.StaticSignConfig(
-                sign_key=args.sign_key, sign_password=args.sign_password.encode("utf-8")
-            )
+        static_sign_config=static_sign_config,
+        url_config=(
+            cosign.URLSigningConfig()
+            .set_tlog_url(args.rekor_url)
+            .set_fulcio_url(args.fulcio_url)
+            .set_issuer_url(args.oidc_issuer)
         ),
-        rekor_config=rekor_config,
-        keyless_config=_check_empty_config(
-            cosign.KeylessSignConfig(
-                fulcio_url=args.fulcio_url,
-                token_file=args.oidc_token,
-            )
-        ),
+        keyless_token_file=args.oidc_token,
     )
+    keyless_verify_config = None
+    if args.oidc_identity_pattern and args.oidc_issuer:
+        keyless_verify_config = cosign.KeylessVerifyConfig(
+            identity_pattern=args.oidc_identity_pattern, oidc_issuer=args.oidc_issuer
+        )
     verify_config = cosign.VerifyConfig(
         static_verify_key=args.verify_key,
-        rekor_config=rekor_config,
-        keyless_verify_config=_check_empty_config(
-            cosign.KeylessVerifyConfig(
-                issuer_url=args.oidc_issuer,
-                identity_pattern=args.oidc_identity_pattern,
-            ),
-        ),
+        keyless_verify_config=keyless_verify_config,
     )
 
     # the snapshot_spec is joined with the data_dir as previous tasks provide
@@ -253,7 +226,7 @@ async def augment_component_sboms(
     result_details = await augment_sboms(config, snapshot)
     if not all(result_details):
         raise SBOMError("Could not augment all SBOMs!")
-    LOGGER.debug("Successfully augmented SBoms for ReleaseId: %s", str(release_id))
+    LOGGER.debug("Successfully augmented SBOMs for ReleaseId: %s", str(release_id))
 
     if not cosign_signer:
         LOGGER.warning(

--- a/tests/integration/oci_client.py
+++ b/tests/integration/oci_client.py
@@ -87,6 +87,7 @@ class ReferrersTagOCIClient:
         cmd = [
             "oras",
             "push",
+            "--plain-http",
             image_pullspec,
             "--config",
             # These are just dummy values that registry requires, but they
@@ -151,6 +152,7 @@ class ReferrersTagOCIClient:
                 "oras",
                 "manifest",
                 "push",
+                "--plain-http",
                 "--media-type",
                 "application/vnd.oci.image.index.v1+json",
                 image_pullspec,
@@ -184,7 +186,7 @@ class ReferrersTagOCIClient:
             str: Image manigest.
         """
         image_pullspec = f"{self.registry}/{name}:{tag}"
-        cmd = ["oras", "manifest", "fetch", image_pullspec]
+        cmd = ["oras", "manifest", "fetch", "--plain-http", image_pullspec]
         code, stdout, stderr = await run_async_subprocess(cmd)
         if code != 0:
             raise RuntimeError(
@@ -312,6 +314,29 @@ class ReferrersTagOCIClient:
             resp.raise_for_status()
             digest = resp.headers["location"].split("/")[-1]
             return digest
+
+    async def copy_image(self, source_ref: str, dest_ref: str) -> None:
+        """
+        Copy an image (or index) from one repo to another within the registry,
+        preserving digests.
+
+        Args:
+            source_ref: Source image reference (e.g. "localhost:9000/src:tag").
+            dest_ref: Destination image reference (e.g. "localhost:9000/dest:tag").
+        """
+        cmd = [
+            "oras",
+            "cp",
+            "--from-plain-http",
+            "--to-plain-http",
+            source_ref,
+            dest_ref,
+        ]
+        code, _, stderr = await run_async_subprocess(cmd)
+        if code != 0:
+            raise RuntimeError(
+                f"Failed to copy {source_ref} to {dest_ref}: {stderr.decode()}"
+            )
 
     async def cleanup(self) -> None:
         """

--- a/tests/integration/test_conforma.py
+++ b/tests/integration/test_conforma.py
@@ -50,7 +50,7 @@ def update_child_image_step(
     Args:
         task (dict[str, Any]): A child image build task from attestation data.
         child_img (Image): A created child image object.
-        child_sbom_digest (str): A reference of the child image SBOM.
+        child_sbom_ref (str): A reference of the child image SBOM.
     """
     for result in task.get("results", []):
         if result.get("name") == "IMAGE_DIGEST":
@@ -210,7 +210,9 @@ async def test_oci_image_sboms_using_conforma(
 
     private_key_path, public_key_path = cosign_keys
     cosign_client = StaticKeySigner(
-        config=SignConfig(StaticSignConfig(sign_key=private_key_path))
+        config=SignConfig(
+            static_sign_config=StaticSignConfig(sign_key=private_key_path)
+        )
     )
 
     child_image = await img_utils.create_child_image(oci_client, repository, tag_prefix)

--- a/tests/integration/test_tekton.py
+++ b/tests/integration/test_tekton.py
@@ -381,6 +381,7 @@ async def test_process_component_sboms_happypath(
     cosign_verify_key: Path,
     create_image_with_build_sbom: CreateImageFunc,
     create_index_with_build_sbom: CreateIndexFunc,
+    oci_client: ReferrersTagOCIClient,
 ) -> None:
     """
     Create an image and an index with build-time SBOMs, run the augmentation
@@ -398,7 +399,7 @@ async def test_process_component_sboms_happypath(
     registry = registry_url.removeprefix("http://")
     repo_with_registry = f"{registry}/{repo_name}"
     cosign_signer = StaticKeySigner(
-        SignConfig(StaticSignConfig(sign_key=cosign_sign_key))
+        SignConfig(static_sign_config=StaticSignConfig(sign_key=cosign_sign_key))
     )
     image = await create_image_with_build_sbom(
         generate_oci_image_case, repo_name, cosign_signer
@@ -406,6 +407,12 @@ async def test_process_component_sboms_happypath(
     index = await create_index_with_build_sbom(
         repo_with_registry, repo_name, [image], cosign_signer
     )
+
+    # Copy the index to all target repos referenced in the snapshot so that
+    # cosign can find the manifest by digest when attesting.
+    source_ref = f"{registry}/{repo_name}:index"
+    await oci_client.copy_image(source_ref, f"{registry}/test:latest")
+    await oci_client.copy_image(source_ref, f"{registry}/anothertest:1.0")
 
     snapshot: dict[str, Any] = {
         "components": [
@@ -562,7 +569,7 @@ async def test_process_component_sboms_big_release(
 
     sbom_ref = await oci_client.attach_sbom(image, "spdx", sbom.encode())
     cosign_signer = StaticKeySigner(
-        SignConfig(StaticSignConfig(sign_key=cosign_sign_key))
+        SignConfig(static_sign_config=StaticSignConfig(sign_key=cosign_sign_key))
     )
     await add_provenance_to_sbom(cosign_signer, sbom_ref, image)
 

--- a/tests/oci/test_cosign.py
+++ b/tests/oci/test_cosign.py
@@ -255,92 +255,15 @@ class TestStaticSigner:
     @pytest.fixture
     def client(self) -> cosign.StaticKeySigner:
         return cosign.StaticKeySigner(
-            cosign.SignConfig(cosign.StaticSignConfig(sign_key=self.signing_key))
+            cosign.SignConfig(
+                static_sign_config=cosign.StaticSignConfig(sign_key=self.signing_key)
+            )
         )
 
     @pytest.mark.asyncio
     async def test_attest_sbom_no_signing_key(self) -> None:
         with pytest.raises(SBOMError):
             cosign.StaticKeySigner(cosign.SignConfig())
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        [
-            "sbom_format",
-            "rekor_url",
-            "rekor_key",
-            "expected_keywords",
-            "subprocess_code",
-            "subprocess_stderr",
-            "raises_exc",
-        ],
-        [
-            (
-                SBOMFormat.CDX_V1_5,
-                "foo",
-                Path("/a"),
-                {"cyclonedx", "--rekor-url=foo"},
-                0,
-                b"warning: foo",
-                None,
-            ),
-            (
-                SBOMFormat.SPDX_2_3,
-                None,
-                None,
-                {"spdxjson", "--tlog-upload=false"},
-                1,
-                b"Me ded",
-                SBOMError,
-            ),
-        ],
-    )
-    @patch("mobster.oci.cosign.static.run_async_subprocess")
-    @patch("mobster.oci.cosign.static.make_oci_auth_file", MagicMock())
-    @patch("mobster.oci.cosign.static.tempfile.NamedTemporaryFile", MagicMock())
-    async def test_attest_sbom(
-        self,
-        mock_run_subprocess: AsyncMock,
-        sbom_format: SBOMFormat,
-        rekor_url: str | None,
-        rekor_key: Path | None,
-        expected_keywords: set[str],
-        subprocess_code: int,
-        subprocess_stderr: bytes,
-        raises_exc: type[Exception] | None,
-        client: cosign.StaticKeySigner,
-        caplog: LogCaptureFixture,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        if rekor_key and rekor_url:
-            rekor_config = cosign.RekorConfig(rekor_url, rekor_key)
-        else:
-            rekor_config = None
-        mock_run_subprocess.return_value = subprocess_code, b"", subprocess_stderr
-        kwargs = {
-            "sbom_path": Path("/foo"),
-            "image_ref": "quay.io/foo@sha256:a",
-            "sbom_format": sbom_format,
-        }
-        monkeypatch.setattr(client, "rekor_config", rekor_config)
-        if not raises_exc:
-            await client.attest_sbom(**kwargs)  # type: ignore[arg-type]
-        else:
-            with pytest.raises(raises_exc):
-                await client.attest_sbom(**kwargs)  # type: ignore[arg-type]
-                assert subprocess_stderr.decode() in caplog.messages[-1]
-        mock_run_subprocess.assert_awaited_once()
-        cosign_command = mock_run_subprocess.call_args_list[0].args[0]
-        assert cosign_command[0] == "cosign"
-        assert cosign_command[1] == "attest"
-        if not rekor_url:
-            assert "--rekor" not in " ".join(cosign_command)
-            assert "--tlog-upload=false" in cosign_command
-        else:
-            assert f"--rekor-url={rekor_url}" in cosign_command
-            assert "--tlog-upload=false" not in cosign_command
-        for expected_command_expression in expected_keywords:
-            assert expected_command_expression in cosign_command
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -380,11 +303,11 @@ class TestKeylessSigner:
     @pytest.fixture
     def keyless_config(self) -> Generator[cosign.SignConfig, None, None]:
         yield cosign.SignConfig(
-            rekor_config=cosign.RekorConfig(rekor_url="foo"),
-            keyless_config=cosign.KeylessSignConfig(
-                fulcio_url="bar",
-                token_file=Path("/tmp"),
-            ),
+            keyless_token_file=Path("/tmp"),
+            url_config=cosign.URLSigningConfig()
+            .set_tlog_url("foo")
+            .set_fulcio_url("bar")
+            .set_issuer_url("WhatIsYourIssueIWillSolveIt.com"),
         )
 
     @pytest.fixture
@@ -397,7 +320,12 @@ class TestKeylessSigner:
             yield cosign_client
 
     @pytest.mark.asyncio
-    async def test_attest_sbom(self, fake_keyless_cosign: cosign.KeylessSigner) -> None:
+    @patch("mobster.oci.cosign.config.URLSigningConfig.file")
+    async def test_attest_sbom(
+        self,
+        mock_url_config_manager: MagicMock,
+        fake_keyless_cosign: cosign.KeylessSigner,
+    ) -> None:
         with patch(
             "mobster.oci.cosign.keyless.run_async_subprocess",
             return_value=(0, b"", b""),
@@ -409,13 +337,13 @@ class TestKeylessSigner:
             [
                 "cosign",
                 "attest",
+                "--signing-config",
+                str(
+                    mock_url_config_manager.return_value.__enter__.return_value.absolute.return_value
+                ),
                 "--yes",
                 "--type",
                 "spdxjson",
-                "--rekor-url",
-                "foo",
-                "--fulcio-url",
-                "bar",
                 "--identity-token",
                 "/tmp",
                 "--predicate",
@@ -449,58 +377,6 @@ class TestKeylessSigner:
 
 
 class TestKeylessFetcher:
-    @pytest.mark.parametrize(
-        ["tuf_exists", "rekor_config", "keyless_config", "success"],
-        [
-            (
-                False,
-                cosign.RekorConfig("foo", Path("bar")),
-                cosign.KeylessVerifyConfig("foobar", "barfoo"),
-                False,
-            ),
-            (
-                True,
-                None,
-                cosign.KeylessVerifyConfig("foobar", "barfoo"),
-                False,
-            ),
-            (
-                True,
-                cosign.RekorConfig("foo", Path("bar")),
-                None,
-                False,
-            ),
-            (
-                True,
-                cosign.RekorConfig("foo", Path("bar")),
-                cosign.KeylessVerifyConfig("foobar", "barfoo"),
-                True,
-            ),
-        ],
-    )
-    def test_invalid_config(
-        self,
-        tuf_exists: bool,
-        rekor_config: cosign.RekorConfig,
-        keyless_config: cosign.KeylessVerifyConfig,
-        success: bool,
-    ) -> None:
-        with patch("mobster.oci.cosign.keyless.check_tuf") as fake_check_tuf:
-            fake_check_tuf.return_value = tuf_exists
-
-            def get_fetcher() -> cosign.KeylessSBOMFetcher:
-                return cosign.KeylessSBOMFetcher(
-                    cosign.VerifyConfig(
-                        rekor_config=rekor_config, keyless_verify_config=keyless_config
-                    )
-                )
-
-            if success:
-                assert get_fetcher() is not None
-            else:
-                with pytest.raises(SBOMError):
-                    get_fetcher()
-
     @pytest.mark.asyncio
     @patch("mobster.oci.cosign.keyless.check_tuf")
     @patch("mobster.oci.cosign.keyless.run_async_subprocess")
@@ -518,8 +394,9 @@ class TestKeylessFetcher:
         assert (
             await cosign.KeylessSBOMFetcher(
                 cosign.VerifyConfig(
-                    rekor_config=cosign.RekorConfig("a"),
-                    keyless_verify_config=cosign.KeylessVerifyConfig("aa", "aaa"),
+                    keyless_verify_config=cosign.KeylessVerifyConfig(
+                        identity_pattern="aaa", oidc_issuer="aa"
+                    )
                 )
             ).fetch_sbom(MagicMock(reference="aaaa"))
         ).doc == {"never gonna": [{"give you": "up"}, {"let you": "down"}]}
@@ -536,8 +413,9 @@ class TestKeylessFetcher:
         with pytest.raises(SBOMError):
             await cosign.KeylessSBOMFetcher(
                 cosign.VerifyConfig(
-                    rekor_config=cosign.RekorConfig("a"),
-                    keyless_verify_config=cosign.KeylessVerifyConfig("aa", "aaa"),
+                    keyless_verify_config=cosign.KeylessVerifyConfig(
+                        identity_pattern="aaa", oidc_issuer="aa"
+                    )
                 )
             ).fetch_sbom(MagicMock(reference="aaaa"))
 
@@ -553,11 +431,9 @@ class TestGetCosign:
             ),
             (
                 cosign.VerifyConfig(
-                    rekor_config=cosign.RekorConfig(rekor_url="a"),
                     keyless_verify_config=cosign.KeylessVerifyConfig(
-                        issuer_url="foo",
-                        identity_pattern="bar",
-                    ),
+                        identity_pattern="bar", oidc_issuer="foo"
+                    )
                 ),
                 cosign.KeylessSBOMFetcher,
             ),

--- a/tests/test_tekton.py
+++ b/tests/test_tekton.py
@@ -12,16 +12,7 @@ from mobster.cmd.upload.upload import (
     TPAUploadReport,
     UploadConfig,
 )
-from mobster.oci.cosign import (
-    KeylessSignConfig,
-    KeylessVerifyConfig,
-    RekorConfig,
-    SignConfig,
-    StaticSignConfig,
-    VerifyConfig,
-)
-from mobster.oci.cosign.keyless import KeylessSBOMFetcher
-from mobster.oci.cosign.static import StaticKeyFetcher
+from mobster.oci import cosign
 from mobster.release import ReleaseId
 from mobster.tekton.common import upload_sboms
 from mobster.tekton.component import (
@@ -119,6 +110,12 @@ async def test_parse_component_args_keyless(mock_augment_sboms: AsyncMock) -> No
             "spam",
         ]
     )
+    expected_file_config = (
+        cosign.URLSigningConfig()
+        .set_fulcio_url("a")
+        .set_tlog_url("https://spam.example")
+        .set_issuer_url("https://foo")
+    )
     assert parsed_args == ProcessComponentArgs(
         data_dir=Path("foo"),
         snapshot_spec=Path("foo/bar"),
@@ -133,24 +130,19 @@ async def test_parse_component_args_keyless(mock_augment_sboms: AsyncMock) -> No
         skip_s3_upload=False,
         augment_concurrency=8,
         attestation_concurrency=4,
-        cosign_sign_config=SignConfig(
-            keyless_config=KeylessSignConfig(
-                fulcio_url="a",
-                token_file=Path("/tmp/token"),
-            ),
-            rekor_config=RekorConfig(rekor_url="https://spam.example", rekor_key=None),
+        cosign_sign_config=cosign.SignConfig(
+            keyless_token_file=Path("/tmp/token"),
+            url_config=expected_file_config,
         ),
-        cosign_verify_config=VerifyConfig(
-            keyless_verify_config=KeylessVerifyConfig(
-                issuer_url="https://foo",
-                identity_pattern=".*",
+        cosign_verify_config=cosign.VerifyConfig(
+            keyless_verify_config=cosign.KeylessVerifyConfig(
+                identity_pattern=".*", oidc_issuer="https://foo"
             ),
-            rekor_config=RekorConfig(rekor_url="https://spam.example", rekor_key=None),
         ),
         release_data=Path("foo/spam"),
     )
     await process_component_sboms(parsed_args)
-    assert isinstance(mock_augment_sboms.call_args.args[3], KeylessSBOMFetcher)
+    assert isinstance(mock_augment_sboms.call_args.args[3], cosign.KeylessSBOMFetcher)
 
 
 @pytest.mark.asyncio
@@ -174,8 +166,6 @@ async def test_parse_component_args_static(mock_augment_sboms: AsyncMock) -> Non
             "https://spam.example",
             "--sign-key",
             "a",
-            "--rekor-key",
-            "/tmp/public_key",
             "--verify-key",
             "/tmp/public_key_cosign",
             "--atlas-api-url",
@@ -187,6 +177,7 @@ async def test_parse_component_args_static(mock_augment_sboms: AsyncMock) -> Non
             "spam",
         ]
     )
+    expected_url_config = cosign.URLSigningConfig().set_tlog_url("https://spam.example")
     assert parsed_args == ProcessComponentArgs(
         data_dir=Path("foo"),
         snapshot_spec=Path("foo/bar"),
@@ -201,24 +192,19 @@ async def test_parse_component_args_static(mock_augment_sboms: AsyncMock) -> Non
         skip_s3_upload=False,
         augment_concurrency=8,
         attestation_concurrency=4,
-        cosign_sign_config=SignConfig(
-            rekor_config=RekorConfig(
-                rekor_url="https://spam.example", rekor_key=Path("/tmp/public_key")
-            ),
-            static_sign_config=StaticSignConfig(
+        cosign_sign_config=cosign.SignConfig(
+            url_config=expected_url_config,
+            static_sign_config=cosign.StaticSignConfig(
                 sign_key="a",  # type: ignore
             ),
         ),
-        cosign_verify_config=VerifyConfig(
-            rekor_config=RekorConfig(
-                rekor_url="https://spam.example", rekor_key=Path("/tmp/public_key")
-            ),
+        cosign_verify_config=cosign.VerifyConfig(
             static_verify_key="/tmp/public_key_cosign",  # type: ignore
         ),
         release_data=Path("foo/spam"),
     )
     await process_component_sboms(parsed_args)
-    assert isinstance(mock_augment_sboms.call_args.args[3], StaticKeyFetcher)
+    assert isinstance(mock_augment_sboms.call_args.args[3], cosign.StaticKeyFetcher)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Migrated Mobster from Cosign v2 to v3.

Requires the update for `cosign`, `oras` and `ec` locally.

This also changes the format in which we attest the SBOMs. Cosign v3 uses the Cosign bundle natively and therefore to check SBOMs, a different command is needed to parse it from the atestation: `cosign download attestation --predicate-type=spdxjson <spec> | jq -r .dsseEnvelope.payload | base64 -d | jq .` (Does not affect `cosign verify-attestation`, that command automatically de-encapsulates the attestation from the bundle.)

## Testing

- [x] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [x] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [x] Konflux CI pipeline passes
- [x] Tested using a custom TSF deployment, produced quay.io/mszymutk_konflux_test/default-managed-tenant/default-managed-tenant-fd9b01/testrepo-component@sha256:5d211454a2e4bba8f4056bb68cbb61690ccd9b8b999a995ed82e7ae2a0d0f3fd

## Checklist

- [x] Documentation updated if needed (updated relevant docstrings)
- [x] Coverage remains at 95%+
