### PR TITLE
feat(ISV-6787): add yq to Mobster image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,10 +51,11 @@ COPY --from=builder /app /app
 
 USER 0
 
-# Copy needed binaries for SBOM augmentation
+# Copy needed binaries for SBOM augmentation & metadata manipulation
 COPY --from=golang /usr/local/bin/oras /usr/bin/oras
 COPY --from=golang /usr/local/bin/cosign /usr/bin/cosign
 COPY --from=golang /usr/local/bin/syft /usr/bin/syft
+COPY --from=golang /usr/local/bin/yq /usr/bin/yq
 # Copy license to the container
 COPY LICENSE /licenses/
 


### PR DESCRIPTION
## Summary

add yq to Mobster image to be able to update buildprobe metadata with additional images

## Related Issues

ISV-6787

## Testing

- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
