### PR TITLE
test: fix slow tests

### DIFF
--- a/tests/integration/test_tekton.py
+++ b/tests/integration/test_tekton.py
@@ -577,6 +577,11 @@ async def test_process_component_sboms_big_release(
         repo_with_registry, repo_name, [image], cosign_signer
     )
 
+    # Copy the index to the target repo referenced in the snapshot so that
+    # cosign can find the manifest by digest when attesting.
+    source_ref = f"{registry}/{repo_name}:index"
+    await oci_client.copy_image(source_ref, f"{registry}/test:latest")
+
     # We assign a unique tag to each component, so that we upload different
     # SBOMs. TPA has trouble when uploading multiple identical large SBOMs
     # concurrently. Based on the number of workers, the final state of TPA


### PR DESCRIPTION
## Summary

I noticed the slow tests broke down. It seems it was caused by forgetting to migrate those tests during the Cosign v3 migration. In the meantime I have disabled the slow tests in Konflux.

## Related Issues

## Testing

- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
