### PR TITLE
chore(ISV-6787): de-deprecate extra images arg

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -55,7 +55,6 @@ USER 0
 COPY --from=golang /usr/local/bin/oras /usr/bin/oras
 COPY --from=golang /usr/local/bin/cosign /usr/bin/cosign
 COPY --from=golang /usr/local/bin/syft /usr/bin/syft
-COPY --from=golang /usr/local/bin/yq /usr/bin/yq
 # Copy license to the container
 COPY LICENSE /licenses/
 

--- a/docs/sboms/oci_image.md
+++ b/docs/sboms/oci_image.md
@@ -65,12 +65,12 @@ mobster --verbose  generate oci-image \
 - `--output` -- where to save the SBOM. prints it to STDOUT if this is not specified
 - `--arch` -- Image architecture in OCI format (e.g., `amd64`, `arm64`, `ppc64le`, `s390x`). Linux kernel format values (e.g., `x86_64`, `aarch64`) are also accepted and normalized automatically to the OCI format. Defaults to the architecture of the current system.
 - `--skip-validation` -- skips validation of the SBOM
+- `--additional-base-image` -- base (builder) image to add, can be specified multiple times. Expects the format `<registry>/<repository>:<tag>@sha256:<digest value>`.
 
 ### Deprecated arguments (will be removed in future versions and fully replaced by --metadata-path)
 - `--parsed-dockerfile-path` -- points to a dockerfile processed by `dockerfile-json`. Use `--metadata-path` instead.
 - `--base-image-digest-file` -- points to a file with digests for images used in Dockerfile. Expected format: `<registry>/<repository>:<tag> <registry>/<repository>:<tag>@sha256:<digest>`. Use `--metadata-path` instead.
 - `--dockerfile-target` -- the name of the build target from the Dockerfile. Use `--metadata-path` instead.
-- `--additional-base-image` -- base (builder) image to add, can be specified multiple times. Expects the format `<registry>/<repository>:<tag>@sha256:<digest value>`. Use `--metadata-path` instead.
 
 ## Generating a (non-hermetic) SBOM from scratch
 

--- a/src/mobster/cli.py
+++ b/src/mobster/cli.py
@@ -196,8 +196,7 @@ def generate_oci_image_parser(subparsers: Any) -> None:
         type=validated_additional_reference,
         action="append",
         default=[],
-        help="[Deprecated: use --metadata-path] "
-        "Base (builder) image to add, can be specified multiple times. "
+        help="Base (builder) image to add, can be specified multiple times. "
         "Expects the format <registry>/<repository>:<tag>@sha256:<digest value>",
     )
 

--- a/src/mobster/cmd/generate/oci_image/__init__.py
+++ b/src/mobster/cmd/generate/oci_image/__init__.py
@@ -545,7 +545,9 @@ class GenerateOciImageCommand(GenerateCommandWithOutputTypeSelector):
                     sbom, base_images_refs, base_images_map
                 )
 
-            # Extending with additional base images
+        # Extending with additional base images (e.g. images for scripts
+        # used in build automation specific for the given pipeline)
+        if self.cli_args.additional_base_image:
             for image_ref in self.cli_args.additional_base_image:
                 image_object = Image.from_oci_artifact_reference(image_ref)
                 await extend_sbom_with_image_reference(

--- a/tests/cmd/generate/oci_image/test_module_init.py
+++ b/tests/cmd/generate/oci_image/test_module_init.py
@@ -609,6 +609,34 @@ async def test_execute_deprecated_path_no_attribute_error(
 
 
 @pytest.mark.asyncio
+async def test_additional_base_image_merges_with_metadata_extra_images(
+    test_case_spdx_with_extra_image: GenerateOciImageTestCase,
+) -> None:
+    """Verify that --additional-base-image entries and metadata extra_images
+    both appear in the final SBOM."""
+    cli_image_ref = "quay.io/extra/tooling:v1@sha256:aabbccddaabbccddaabbccddaabbccdd"
+    test_case_spdx_with_extra_image.args.additional_base_image = [cli_image_ref]
+
+    command = GenerateOciImageCommand(test_case_spdx_with_extra_image.args)
+    sbom = await command.execute()
+    sbom_dict = await GenerateOciImageCommand.dump_sbom_to_dict(sbom)
+
+    purls = {
+        ref["referenceLocator"]
+        for pkg in sbom_dict.get("packages", [])
+        for ref in pkg.get("externalRefs", [])
+        if ref.get("referenceType") == "purl"
+    }
+
+    assert any("quay.io/ubi9" in p for p in purls), (
+        "Extra image from metadata not found in SBOM"
+    )
+    assert any("quay.io/extra/tooling" in p for p in purls), (
+        "Additional base image from CLI not found in SBOM"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_case",
     [


### PR DESCRIPTION

## Summary

additional base images is now not deprecated. YQ can be removed from the build pipeline

## Related Issues

ISV-6787

## Testing

- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
