### PR TITLE
feat(ISV-7542): stream file in TPA upload_sbom

### DIFF
--- a/src/mobster/cmd/upload/oidc.py
+++ b/src/mobster/cmd/upload/oidc.py
@@ -225,7 +225,7 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
     # Mypy doesn't recognize that either a value is returned
     # or an exception is raised in all cases
     async def _request(  # type: ignore[return]
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments, too-many-locals
         self,
         method: str,
         url: str,
@@ -246,7 +246,10 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
             method: HTTP method (GET, POST, ...)
             url: Relative URL of the endpoint. Will be combined with the base URL.
             headers: headers to add to the request. Defaults to None.
-            content: data to send in the request. Defaults to None.
+            content: Request body, or a zero-arg callable that returns a fresh body
+                for each attempt (useful for streaming uploads that must be
+                re-opened on retry). Accepts any httpx-compatible body (bytes,
+                str, iterable, or async iterable). Defaults to None.
             params: Parameters to add to the request. Defaults to None.
             retries: Maximum number of retries. Default to 10.
             backoff_factor: A backoff factor to apply between attempts.
@@ -273,10 +276,12 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
         for attempt in range(retries):
             await self._ensure_valid_token()
             try:
+                # Resolve callables per attempt so streaming bodies can be recreated
+                request_content = content() if callable(content) else content
                 resp = await self.client.request(  # type:ignore[union-attr]
                     method,
                     effective_url,
-                    content=content,
+                    content=request_content,
                     params=params,
                     headers=headers,
                 )
@@ -370,7 +375,8 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
 
         Args:
             url: endpoint to call
-            content: data to send in request body
+            content: Request body, or a zero-arg callable that returns a fresh
+                body for each attempt (see `_request`).
             headers: headers to add to the request.
                 Defaults to None.
             params: Parameters to add to the request.
@@ -401,7 +407,8 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
 
         Args:
             url: endpoint to call
-            content: data to send in request body
+            content: Request body, or a zero-arg callable that returns a fresh
+                body for each attempt (see `_request`).
             headers: headers to add to the request.
                 Defaults to None.
             params: Parameters to add to the request.

--- a/src/mobster/cmd/upload/oidc.py
+++ b/src/mobster/cmd/upload/oidc.py
@@ -3,6 +3,7 @@ OIDC client wrapped around httpx
 """
 
 import asyncio
+import inspect
 import logging
 import ssl
 import time
@@ -20,6 +21,19 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_TIMEOUT_SECONDS = 60
 DEFAULT_CONNECT_TIMEOUT_SECONDS = 5
 TOKEN_EXPIRY_BUFFER_SECONDS = 15
+
+
+async def _close_request_content(request_content: Any) -> None:
+    """Best-effort cleanup of per-attempt request body (e.g. async generators)."""
+    if request_content is None:
+        return
+    try:
+        if hasattr(request_content, "aclose"):
+            await request_content.aclose()
+        elif hasattr(request_content, "close"):
+            request_content.close()
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.debug("Failed to close request content", exc_info=True)
 
 
 class OIDCAuthenticationError(Exception):
@@ -249,7 +263,8 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
             content: Request body, or a zero-arg callable that returns a fresh body
                 for each attempt (useful for streaming uploads that must be
                 re-opened on retry). Accepts any httpx-compatible body (bytes,
-                str, iterable, or async iterable). Defaults to None.
+                str, iterable, or async iterable). If the factory is async, its
+                return value is awaited. Defaults to None.
             params: Parameters to add to the request. Defaults to None.
             retries: Maximum number of retries. Default to 10.
             backoff_factor: A backoff factor to apply between attempts.
@@ -275,9 +290,12 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
         self._assert_client()
         for attempt in range(retries):
             await self._ensure_valid_token()
+            request_content = None
             try:
                 # Resolve callables per attempt so streaming bodies can be recreated
                 request_content = content() if callable(content) else content
+                if inspect.isawaitable(request_content):
+                    request_content = await request_content
                 resp = await self.client.request(  # type:ignore[union-attr]
                     method,
                     effective_url,
@@ -331,6 +349,8 @@ class OIDCClientCredentialsClient:  # pylint: disable=too-few-public-methods,too
                 # capture broad exception and raise it without retrying
                 LOGGER.exception("HTTP %s request failed: %s", method, exc)
                 raise
+            finally:
+                await _close_request_content(request_content)
 
     async def get(
         self,

--- a/src/mobster/cmd/upload/tpa.py
+++ b/src/mobster/cmd/upload/tpa.py
@@ -96,30 +96,49 @@ class TPAClient(OIDCClientCredentialsClient):
         if labels_params := TPAClient._get_labels_params(labels):
             params.update(labels_params)
 
-        headers = {"content-type": "application/json"}
-        async with aiofiles.open(sbom_filepath, "rb") as sbom_file:
-            file_content = await sbom_file.read()
-            try:
-                response = await self.post(
-                    url,
-                    content=file_content,
-                    headers=headers,
-                    params=params,
-                    retries=retries,
-                )
-                urn: str = json.loads(response.content)["id"]
-                return urn
-            except RetryExhaustedException as err:
-                raise TPATransientError(
-                    "Retries exhausted for transient TPA errors"
-                ) from err
-            except httpx.HTTPStatusError as err:
-                raise TPAError(
-                    f"Failed to upload to TPA with code: {err.response.status_code} and"
-                    f" message: {err.response.content.decode()}"
-                ) from err
-            except httpx.HTTPError as err:
-                raise TPAError("HTTP request for upload failed") from err
+        headers = {
+            "content-type": "application/json",
+            "content-length": str(sbom_filepath.stat().st_size),
+        }
+        try:
+            response = await self.post(
+                url,
+                content=lambda: TPAClient._iter_sbom_file(sbom_filepath),
+                headers=headers,
+                params=params,
+                retries=retries,
+            )
+            urn: str = json.loads(response.content)["id"]
+            return urn
+        except RetryExhaustedException as err:
+            raise TPATransientError(
+                "Retries exhausted for transient TPA errors"
+            ) from err
+        except httpx.HTTPStatusError as err:
+            raise TPAError(
+                f"Failed to upload to TPA with code: {err.response.status_code} and"
+                f" message: {err.response.content.decode()}"
+            ) from err
+        except httpx.HTTPError as err:
+            raise TPAError("HTTP request for upload failed") from err
+
+    @staticmethod
+    async def _iter_sbom_file(
+        path: Path, chunk_size: int = 64 * 1024
+    ) -> AsyncGenerator[bytes, None]:
+        """
+        Yield the SBOM file in chunks for streaming upload.
+
+        Args:
+            path: Path to the SBOM file.
+            chunk_size: Size of each chunk in bytes. Defaults to 64 KiB.
+
+        Yields:
+            bytes: File content chunks.
+        """
+        async with aiofiles.open(path, "rb") as sbom_file:
+            while chunk := await sbom_file.read(chunk_size):
+                yield chunk
 
     async def list_sboms(
         self, query: str, sort: str, page_size: int = 50

--- a/src/mobster/cmd/upload/tpa.py
+++ b/src/mobster/cmd/upload/tpa.py
@@ -134,7 +134,7 @@ class TPAClient(OIDCClientCredentialsClient):
             chunk_size: Size of each chunk in bytes. Defaults to 64 KiB.
 
         Yields:
-            bytes: File content chunks.
+            File content chunks.
         """
         async with aiofiles.open(path, "rb") as sbom_file:
             while chunk := await sbom_file.read(chunk_size):

--- a/tests/cmd/upload/test_oidc.py
+++ b/tests/cmd/upload/test_oidc.py
@@ -307,6 +307,148 @@ async def test__request_content_factory_on_exhausted_retries(
 
 
 @pytest.mark.asyncio
+@patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
+async def test__request_async_content_factory_invoked_per_attempt(
+    mock_fetch_token: AsyncMock,
+    httpx_mock: HTTPXMock,
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
+    """Async content factory must be awaited; invoked once per attempt."""
+    body = b"async-chunk-a" + b"async-chunk-b"
+    factory_calls = 0
+
+    async def content_factory() -> AsyncGenerator[bytes, None]:
+        nonlocal factory_calls
+        factory_calls += 1
+
+        async def _gen() -> AsyncGenerator[bytes, None]:
+            yield b"async-chunk-a"
+            yield b"async-chunk-b"
+
+        return _gen()
+
+    httpx_mock.add_response(
+        url=f"{BASE_URL}hello",
+        method="post",
+        headers=AUTHORIZATION_HEADER,
+        status_code=500,
+    )
+    httpx_mock.add_response(
+        url=f"{BASE_URL}hello",
+        method="post",
+        headers=AUTHORIZATION_HEADER,
+        status_code=200,
+        text="ok",
+    )
+
+    resp = await oidc_client._request(
+        "post",
+        "hello",
+        content=content_factory,
+        retries=3,
+        backoff_factor=0.01,
+    )
+
+    assert resp.status_code == 200
+    assert factory_calls == 2
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    assert all(req.content == body for req in requests)
+    mock_fetch_token.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_close_request_content_async_generator() -> None:
+    closed = False
+
+    async def _gen() -> AsyncGenerator[bytes, None]:
+        nonlocal closed
+        try:
+            yield b"chunk"
+        finally:
+            closed = True
+
+    gen = _gen()
+    await anext(gen)
+    await oidc._close_request_content(gen)
+    assert closed
+
+
+@pytest.mark.asyncio
+async def test_close_request_content_sync_closeable() -> None:
+    mock_content = MagicMock(spec=["close"])
+
+    await oidc._close_request_content(mock_content)
+
+    mock_content.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_request_content_none() -> None:
+    await oidc._close_request_content(None)
+
+
+@pytest.mark.asyncio
+@patch("mobster.cmd.upload.oidc._close_request_content", new_callable=AsyncMock)
+@patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
+async def test__request_closes_content_each_attempt(
+    mock_fetch_token: AsyncMock,
+    mock_close_content: AsyncMock,
+    httpx_mock: HTTPXMock,
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
+    httpx_mock.add_response(
+        url=f"{BASE_URL}hello",
+        method="post",
+        headers=AUTHORIZATION_HEADER,
+        status_code=500,
+    )
+    httpx_mock.add_response(
+        url=f"{BASE_URL}hello",
+        method="post",
+        headers=AUTHORIZATION_HEADER,
+        status_code=200,
+        text="ok",
+    )
+
+    await oidc_client._request(
+        "post",
+        "hello",
+        content=b"payload",
+        retries=3,
+        backoff_factor=0.01,
+    )
+
+    assert mock_close_content.await_count == 2
+    mock_fetch_token.assert_awaited()
+
+
+@pytest.mark.asyncio
+@patch("mobster.cmd.upload.oidc._close_request_content", new_callable=AsyncMock)
+@patch("httpx.AsyncClient.request")
+@patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
+async def test__request_closes_content_on_non_retryable_error(
+    mock_fetch_token: AsyncMock,
+    mock_httpx_request: AsyncMock,
+    mock_close_content: AsyncMock,
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
+    mock_httpx_request.side_effect = ZeroDivisionError("Error")
+
+    with pytest.raises(ZeroDivisionError):
+        await oidc_client._request(
+            "post",
+            "hello",
+            content=b"payload",
+            retries=2,
+            backoff_factor=0.01,
+        )
+
+    mock_close_content.assert_awaited_once()
+    mock_fetch_token.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @patch("httpx.AsyncClient.request")
 @patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
 async def test__request_fail_on_error(

--- a/tests/cmd/upload/test_oidc.py
+++ b/tests/cmd/upload/test_oidc.py
@@ -223,6 +223,90 @@ async def test__request_fail_on_request(
 
 
 @pytest.mark.asyncio
+@patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
+async def test__request_content_factory_invoked_per_attempt(
+    mock_fetch_token: AsyncMock,
+    httpx_mock: HTTPXMock,
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
+    """Content factory must be called once per attempt so streams can be recreated."""
+    body = b"chunk-a" + b"chunk-b"
+    factory_calls = 0
+
+    def content_factory() -> AsyncGenerator[bytes, None]:
+        nonlocal factory_calls
+        factory_calls += 1
+
+        async def _gen() -> AsyncGenerator[bytes, None]:
+            yield b"chunk-a"
+            yield b"chunk-b"
+
+        return _gen()
+
+    httpx_mock.add_response(
+        url=f"{BASE_URL}hello",
+        method="post",
+        headers=AUTHORIZATION_HEADER,
+        status_code=500,
+    )
+    httpx_mock.add_response(
+        url=f"{BASE_URL}hello",
+        method="post",
+        headers=AUTHORIZATION_HEADER,
+        status_code=200,
+        text="ok",
+    )
+
+    resp = await oidc_client._request(
+        "post",
+        "hello",
+        content=content_factory,
+        retries=3,
+        backoff_factor=0.01,
+    )
+
+    assert resp.status_code == 200
+    assert factory_calls == 2
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    assert all(req.content == body for req in requests)
+    mock_fetch_token.assert_awaited()
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.request")
+@patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
+async def test__request_content_factory_on_exhausted_retries(
+    mock_fetch_token: AsyncMock,
+    mock_httpx_request: AsyncMock,
+    oidc_client: OIDCClientCredentialsClient,
+) -> None:
+    """Factory is invoked once per attempt even when all retries fail."""
+    retries = 3
+    factory_calls = 0
+
+    def content_factory() -> bytes:
+        nonlocal factory_calls
+        factory_calls += 1
+        return b"payload"
+
+    mock_httpx_request.side_effect = httpx.RequestError("Request failed")
+
+    with pytest.raises(RetryExhaustedException):
+        await oidc_client._request(
+            "post",
+            "hello",
+            content=content_factory,
+            retries=retries,
+            backoff_factor=0.01,
+        )
+
+    assert factory_calls == retries
+    assert mock_httpx_request.await_count == retries
+    mock_fetch_token.assert_awaited()
+
+
+@pytest.mark.asyncio
 @patch("httpx.AsyncClient.request")
 @patch("mobster.cmd.upload.oidc.OIDCClientCredentialsClient._fetch_token")
 async def test__request_fail_on_error(

--- a/tests/cmd/upload/test_tpa.py
+++ b/tests/cmd/upload/test_tpa.py
@@ -26,17 +26,13 @@ async def tpa_client() -> AsyncGenerator[TPAClient, None]:
 
 
 @pytest.mark.asyncio
-@patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_success(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
+    mock_post: AsyncMock, tpa_client: TPAClient, tmp_path: Path
 ) -> None:
-    sbom_filepath = Path("/path/to/sbom.json")
     file_content = b'{"sbom": "content"}'
-
-    mock_file = AsyncMock()
-    mock_file.read.return_value = file_content
-    mock_aiofiles_open.return_value.__aenter__.return_value = mock_file
+    sbom_filepath = tmp_path / "sbom.json"
+    sbom_filepath.write_bytes(file_content)
 
     mock_response = httpx.Response(
         200,
@@ -47,29 +43,29 @@ async def test_upload_sbom_success(
 
     response = await tpa_client.upload_sbom(sbom_filepath)
 
-    mock_aiofiles_open.assert_called_once_with(sbom_filepath, "rb")
-    mock_post.assert_called_once_with(
-        "api/v2/sbom",
-        content=file_content,
-        headers={"content-type": "application/json"},
-        params={},
-        retries=3,
-    )
+    mock_post.assert_called_once()
+    assert mock_post.await_args is not None
+    call_kwargs = mock_post.await_args.kwargs
+    assert call_kwargs["headers"] == {
+        "content-type": "application/json",
+        "content-length": str(len(file_content)),
+    }
+    assert call_kwargs["params"] == {}
+    assert call_kwargs["retries"] == 3
+    assert callable(call_kwargs["content"])
+
+    streamed = b"".join([chunk async for chunk in call_kwargs["content"]()])
+    assert streamed == file_content
     assert response == "urn:uuid:12345678-1234-5678-9012-123456789012"
 
 
 @pytest.mark.asyncio
-@patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_error(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
+    mock_post: AsyncMock, tpa_client: TPAClient, tmp_path: Path
 ) -> None:
-    sbom_filepath = Path("/path/to/sbom.json")
-    file_content = b'{"sbom": "content"}'
-
-    mock_file = AsyncMock()
-    mock_file.read.return_value = file_content
-    mock_aiofiles_open.return_value.__aenter__.return_value = mock_file
+    sbom_filepath = tmp_path / "sbom.json"
+    sbom_filepath.write_bytes(b'{"sbom": "content"}')
 
     request = httpx.Request("POST", "https://api.example.com/v1/api/v2/sbom")
     error_response = httpx.Response(500, request=request, content=b"Server Error")
@@ -80,22 +76,18 @@ async def test_upload_sbom_error(
     with pytest.raises(TPAError):
         await tpa_client.upload_sbom(sbom_filepath)
 
-    mock_aiofiles_open.assert_called_once_with(sbom_filepath, "rb")
     mock_post.assert_called_once()
+    assert mock_post.await_args is not None
+    assert callable(mock_post.await_args.kwargs["content"])
 
 
 @pytest.mark.asyncio
-@patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_retry_exhausted_error(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
+    mock_post: AsyncMock, tpa_client: TPAClient, tmp_path: Path
 ) -> None:
-    sbom_filepath = Path("/path/to/sbom.json")
-    file_content = b'{"sbom": "content"}'
-
-    mock_file = AsyncMock()
-    mock_file.read.return_value = file_content
-    mock_aiofiles_open.return_value.__aenter__.return_value = mock_file
+    sbom_filepath = tmp_path / "sbom.json"
+    sbom_filepath.write_bytes(b'{"sbom": "content"}')
 
     mock_post.side_effect = RetryExhaustedException("Retries exhausted")
 
@@ -104,22 +96,31 @@ async def test_upload_sbom_retry_exhausted_error(
 
 
 @pytest.mark.asyncio
-@patch("aiofiles.open")
 @patch("mobster.cmd.upload.tpa.TPAClient.post")
 async def test_upload_sbom_http_error(
-    mock_post: AsyncMock, mock_aiofiles_open: AsyncMock, tpa_client: TPAClient
+    mock_post: AsyncMock, tpa_client: TPAClient, tmp_path: Path
 ) -> None:
-    sbom_filepath = Path("/path/to/sbom.json")
-    file_content = b'{"sbom": "content"}'
-
-    mock_file = AsyncMock()
-    mock_file.read.return_value = file_content
-    mock_aiofiles_open.return_value.__aenter__.return_value = mock_file
+    sbom_filepath = tmp_path / "sbom.json"
+    sbom_filepath.write_bytes(b'{"sbom": "content"}')
 
     mock_post.side_effect = httpx.HTTPError("Connection failed")
 
     with pytest.raises(TPAError):
         await tpa_client.upload_sbom(sbom_filepath)
+
+
+@pytest.mark.asyncio
+async def test_iter_sbom_file_chunks(tmp_path: Path) -> None:
+    content = b"abcdefghijklmnopqrstuvwxyz"
+    sbom_filepath = tmp_path / "sbom.json"
+    sbom_filepath.write_bytes(content)
+
+    chunks = [
+        chunk async for chunk in TPAClient._iter_sbom_file(sbom_filepath, chunk_size=10)
+    ]
+
+    assert chunks == [b"abcdefghij", b"klmnopqrst", b"uvwxyz"]
+    assert b"".join(chunks) == content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`OIDCClientCredentialsClient._request` updated so it can use iterable as content to support large file upload with low memory footprint (file is reopened on retry). `TPAClient.upload_sbom` now uses async generator to upload SBOMs to TPA.

## Related Issues

Fixes ISV-7542

## Testing

- [ ] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
