### PR TITLE
fix: Improve release strategy

### DIFF
--- a/.tekton/mobster-f7a65-push.yaml
+++ b/.tekton/mobster-f7a65-push.yaml
@@ -7,9 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-event: "[push]"
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/on-path-change-ignore: "[tasks/***]"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+       event == "push" && target_branch == "main"
+       && !files.all.all(x, x.matches('^tasks/'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: mobster


### PR DESCRIPTION


## Summary

This introduces a better strategy when it comes to running a release pipeline. The previous implementation would not run the pipeline if the commit included mixed changes (both code and tekton). This uses the CEL expression that will only skip the pipeline if ALL changes are to the tasks.

Ref: https://pipelinesascode.com/docs/guides/event-matching/cel-expressions/#excluding-non-code-changes


## Testing

- [x] All checks pass (see [Tox](../docs/development-environment.md#tox))
- [ ] Integration tests pass (see [Integration Tests](../docs/development-environment.md#integration-tests))
- [ ] Konflux CI pipeline passes

## Checklist

- [ ] Documentation updated if needed
- [ ] Coverage remains at 95%+
