### PR TITLE
fix: pin download-artifact to the latest version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Download built artifact to dist/
-        uses: actions/download-artifact@ad191675b41f6a5b46da9a048cb6893812da158b
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: Packages
           path: dist


### PR DESCRIPTION
## Summary

Recent PR https://github.com/konflux-ci/mobster/pull/478 pinned the download-artifact to an old (Node 20) version, which is regression (see [failed release](https://github.com/konflux-ci/mobster/actions/runs/31711994810/job/94489238514)). This PR pins the latest version 8 as it was before digest pinning. 

## Related Issues

Fixes ISV-7542 - this fix enable Pypi release
